### PR TITLE
fix: exclude GitHub compare links from lychee checks

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -17,5 +17,7 @@ remap = [
 exclude = [
   # Google Docs links are often rate-limited and not critical to validate in this repository,
   # so we exclude them to avoid false positives and improve performance
-  "https://docs.google.com/.*"
+  "https://docs.google.com/.*",
+  # Release Please generates compare links for future releases that 404 until the release is published
+  "https://github.com/.*/compare/.*"
 ]


### PR DESCRIPTION
## Summary
- Exclude GitHub compare links (`/compare/...`) from lychee link checks
- Release Please generates compare URLs referencing tags that don't exist until the release is published, causing false 404 failures in CI

## Test plan
- [ ] Verify lychee no longer reports 404 for `https://github.com/grafana/flint/compare/v0.1.0...v0.2.0`
- [ ] Verify other link checks still run normally