### PR TITLE
docs: add release impact guidance to commit message conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,12 @@ type(optional scope): description
 
 Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`
 
-**Release impact:** This repository uses [release-please](https://github.com/googleapis/release-please). By default, `feat:` and `fix:` trigger new releases, and `breaking:` (or `feat!:` / `fix!:` or commits with a `BREAKING CHANGE` footer) trigger a major version bump. Use `docs:`, `ci:`, or `chore:` for changes that don't affect consumers (documentation, CI workflows, repository config). Misusing `fix:` or `breaking:` for non-functional changes creates unnecessary releases.
+**Release impact:** This repository uses [release-please](https://github.com/googleapis/release-please).
+Only `feat:` and `fix:` trigger new releases, and breaking changes
+(`feat!:` / `fix!:` or commits with a `BREAKING CHANGE` footer) trigger a major version bump.
+Use `docs:`, `ci:`, or `chore:` for changes that don't affect consumers
+(documentation, CI workflows, repository config).
+Misusing `fix:` for non-functional changes creates unnecessary releases.
 
 ## Script Conventions
 


### PR DESCRIPTION
## Summary

- Closed PR #13 (unnecessary v0.2.1 release triggered by `fix:` prefix on a docs-only change)
- Added release impact note to CLAUDE.md commit message conventions, explaining that only `feat` and `fix` types trigger releases

## Context

Commit 817b37d used `fix:` for a docs/CI change, which caused release-please to open an unnecessary release PR. This adds guidance to prevent that in the future.

## Test plan

- [x] `mise run fix` passes