### PR TITLE
feat: add Renovate shareable preset for consuming repos

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,8 @@
     labels: ["automerge-security-update"],
   },
   osvVulnerabilityAlerts: true,
+  // Kept inline (not via "local>.") because renovate-deps.py runs with
+  // --platform=local which cannot resolve local presets.
   customManagers: [
     {
       customType: "regex",

--- a/README.md
+++ b/README.md
@@ -169,27 +169,19 @@ Linters that don't support autofix (like lychee link checker) silently ignore th
 
 ## Automatic version updates with Renovate
 
-To let Renovate automatically update the pinned flint version in your
-`mise.toml`, add this custom manager to your `renovate.json5`:
+Flint provides a [Renovate shareable preset](https://docs.renovatebot.com/config-presets/)
+with custom managers that automatically update:
+
+- **Pinned flint versions** in `mise.toml` (`raw.githubusercontent.com` URLs)
+- **`_VERSION` variables** in `mise.toml` (e.g., `SUPER_LINTER_VERSION`)
+
+Add this to your `renovate.json5`:
 
 ```json5
 {
-  customManagers: [
-    {
-      customType: "regex",
-      description: "Update raw.githubusercontent.com version tags in mise.toml",
-      managerFilePatterns: ["/^mise\\.toml$/"],
-      matchStrings: [
-        "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentValue>v[^/]+)/",
-      ],
-      datasourceTemplate: "github-tags",
-    },
-  ],
+  extends: ["github>grafana/flint"],
 }
 ```
-
-This matches all `raw.githubusercontent.com` URLs in `mise.toml` and updates
-the version tag (e.g., `v0.1.0`) when a new release is published.
 
 ## Per-repo configuration
 

--- a/default.json
+++ b/default.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": "Renovate custom managers for repositories that use flint mise tasks",
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Update _VERSION variables in mise.toml",
+			"managerFilePatterns": ["/^mise\\.toml$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION=\"?(?<currentValue>[^@\"]+?)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?\\s"
+			]
+		},
+		{
+			"customType": "regex",
+			"description": "Update raw.githubusercontent.com version tags in mise.toml",
+			"managerFilePatterns": ["/^mise\\.toml$/"],
+			"matchStrings": [
+				"https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentValue>v[^/]+)/"
+			],
+			"datasourceTemplate": "github-tags"
+		}
+	],
+	"packageRules": [
+		{
+			"matchPackageNames": ["renovate"],
+			"description": "Only update renovate once a week",
+			"schedule": ["before 6am on Monday"]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Adds a [Renovate shareable preset](https://docs.renovatebot.com/config-presets/) (`default.json`) so consuming repos no longer need to copy-paste custom manager configurations.

### What the preset provides

Consuming repos add one line to their `renovate.json5`:

```json5
{
  extends: ["github>grafana/flint"],
}
```

This gives them:

- **`_VERSION` variable tracking** — a regex custom manager that matches `# renovate:` annotated `_VERSION` variables in `mise.toml` (e.g., `SUPER_LINTER_VERSION`), supporting `datasource`, `depName`, `packageName`, `versioning`, and optional `@sha256:` digests
- **Flint version pinning** — a regex custom manager that matches `raw.githubusercontent.com` URLs in `mise.toml` and updates the version tag (e.g., `v0.1.0`) via the `github-tags` datasource
- **Weekly renovate updates** — a package rule that limits `renovate` self-updates to once a week (before 6am on Monday)

### Why flint doesn't use its own preset

The `lint:renovate-deps` task runs Renovate with `--platform=local`, which cannot resolve `local>.` presets. Flint's own `.github/renovate.json5` therefore keeps its custom managers inline, with a comment explaining why.

## Test plan

- [ ] Verify a consuming repo can extend `"github>grafana/flint"` and Renovate resolves the preset
- [ ] Verify `mise run lint` passes (super-linter, links, renovate-deps all green)