### PR TITLE
fix(links): add regex anchors to remap patterns

### DIFF
--- a/tasks/lint/links.sh
+++ b/tasks/lint/links.sh
@@ -54,9 +54,9 @@ build_remap_args() {
 	local head_url="https://github.com/${head_repo}"
 
 	echo "--remap"
-	echo "${base_url}/blob/${base_ref}/(.*) ${head_url}/blob/${head_ref}/\$1"
+	echo "^${base_url}/blob/${base_ref}/(.*)$ ${head_url}/blob/${head_ref}/\$1"
 	echo "--remap"
-	echo "${base_url}/tree/${base_ref}/(.*) ${head_url}/tree/${head_ref}/\$1"
+	echo "^${base_url}/tree/${base_ref}/(.*)$ ${head_url}/tree/${head_ref}/\$1"
 }
 
 run_lychee() {


### PR DESCRIPTION
## Summary

- Add `^` and `$` regex anchors to the lychee `--remap` patterns to prevent partial URL matching

Addresses review feedback from #18 — without anchors, a URL embedded inside another URL (e.g., `https://example.com/link-to-https://github.com/org/repo/blob/main/file.md`) could be incorrectly remapped.

## Test plan

- [x] Lint passes (`mise run lint`)
- [x] CI simulation: remap patterns include `^` prefix and `$` suffix