### PR TITLE
feat(super-linter): default to slim image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,4 +23,12 @@
       matchStrings: ['# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION="?(?<currentValue>[^@"]+?)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"?\\s'],
     },
   ],
+  packageRules: [
+    {
+      matchPackageNames: ["ghcr.io/super-linter/super-linter"],
+      matchCurrentValue: "/^slim-/",
+      description: "Use regex versioning for slim Super-Linter tags (slim-v8.4.0)",
+      versioning: "regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+    },
+  ],
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ controls which Super-Linter image is pulled. **Renovate**, via the
 flint preset, opens PRs to bump both the flint script URL and the
 `SUPER_LINTER_VERSION` value when new versions are available.
 
+**Slim vs full image:** Super-Linter publishes a slim image
+(`slim-v8.4.0`) that is ~2 GB smaller than the full image. The slim
+image excludes Rust, .NET/C#, PowerShell, and ARM template linters.
+Flint defaults to the slim image. To use the full image instead, set
+`SUPER_LINTER_VERSION` to the non-prefixed tag (e.g.
+`v8.4.0@sha256:...`) and update the Renovate `depName` comment
+accordingly (drop the `versioning` override so Renovate uses standard
+Docker versioning).
+
 **Flags:**
 
 | Flag        | Description                                                  |
@@ -143,10 +152,10 @@ the env file before running Super-Linter.
 
 <!-- editorconfig-checker-disable -->
 
-| Variable                | Default                           | Required | Description                                       |
-| ----------------------- | --------------------------------- | -------- | ------------------------------------------------- |
-| `SUPER_LINTER_VERSION`  | —                                 | yes      | Super-Linter image tag (e.g. `v8.4.0@sha256:...`) |
-| `SUPER_LINTER_ENV_FILE` | `.github/config/super-linter.env` | no       | Path to the Super-Linter env file                 |
+| Variable                | Default                           | Required | Description                                                                                   |
+| ----------------------- | --------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `SUPER_LINTER_VERSION`  | —                                 | yes      | Super-Linter image tag (e.g. `slim-v8.4.0@sha256:...` for slim, `v8.4.0@sha256:...` for full) |
+| `SUPER_LINTER_ENV_FILE` | `.github/config/super-linter.env` | no       | Path to the Super-Linter env file                                                             |
 
 <!-- editorconfig-checker-enable -->
 

--- a/default.json
+++ b/default.json
@@ -25,6 +25,12 @@
 			"matchPackageNames": ["renovate"],
 			"description": "Only update renovate once a week",
 			"schedule": ["before 6am on Monday"]
+		},
+		{
+			"matchPackageNames": ["ghcr.io/super-linter/super-linter"],
+			"matchCurrentValue": "/^slim-/",
+			"description": "Use regex versioning for slim Super-Linter tags (slim-v8.4.0)",
+			"versioning": "regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
 		}
 	]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ node = "24.13.1"
 [env]
 RENOVATE_TRACKED_DEPS_EXCLUDE="github-actions,github-runners"
 # renovate: datasource=docker depName=ghcr.io/super-linter/super-linter
-SUPER_LINTER_VERSION="v8.4.0@sha256:c5e3307932203ff9e1e8acfe7e92e894add6266605b5d7fb525fb371a59a26f4"
+SUPER_LINTER_VERSION="slim-v8.4.0@sha256:8421cd4687937ac32a829539d03de51a147c164b42842cbfb20aada83ce1bb0c"
 
 # Dogfood our own lint tasks - use local file paths
 [tasks."lint:super-linter"]


### PR DESCRIPTION
## Summary

- Switch from the full Super-Linter image to the slim variant (~2 GB smaller), which excludes Rust, .NET/C#, PowerShell, and ARM template linters most consuming repos don't need
- Add a `packageRules` entry to the Renovate preset (`default.json`) and flint's own `renovate.json5` that applies regex versioning when the current value starts with `slim-` — this teaches Renovate how to parse `slim-v8.4.0` style tags. The rule only activates for slim tags, so repos using the full image are unaffected (backwards compatible)
- Document the slim vs full image choice in README

## Test plan

- [x] Run `mise run lint:super-linter` locally — confirm it pulls the slim image
- [ ] Run `mise run fix` — confirm autofix works with slim image
- [ ] Verify a consuming repo can override to full image by setting `SUPER_LINTER_VERSION` to a non-prefixed tag
- [ ] Verify Renovate can parse the slim tag and propose updates