### PR TITLE
feat(links): add GitHub URL remaps for line-number and fragment anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,32 @@ When running in default mode, if a config change is detected
 (matching `LYCHEE_CONFIG_CHANGE_PATTERN`), the script falls back
 to `--full` behavior.
 
+**GitHub URL remaps:**
+
+When running on a PR branch, the script automatically remaps GitHub
+`/blob/<base-branch>/` and `/tree/<base-branch>/` URLs so that links
+to the base branch resolve against the PR branch instead. This
+ensures that links like `/blob/main/README.md` don't break when
+the file was added or moved in the PR.
+
+For `/blob/` URLs, three ordered remap rules are applied
+(lychee uses first-match-wins):
+
+1. **Line-number anchors** (`#L123`): GitHub renders these with
+   JavaScript, so lychee can never verify the fragment. The anchor
+   is stripped and the file is checked on the PR branch.
+2. **Other fragment URLs** (`#section`): Remapped to
+   `raw.githubusercontent.com` where lychee can verify the fragment
+   in the raw file content (workaround for
+   [lychee#1729](https://github.com/lycheeverse/lychee/issues/1729)).
+3. **Non-fragment URLs**: Remapped from the base branch to the PR
+   branch (the original behavior).
+
+For `/tree/` URLs, rules 1 and 3 apply (no raw remap needed).
+
+Set `LYCHEE_SKIP_GITHUB_REMAPS=true` to disable all GitHub-specific
+remaps as an escape hatch if they cause unexpected behavior.
+
 **Environment variables:**
 
 <!-- editorconfig-checker-disable -->
@@ -199,6 +225,7 @@ to `--full` behavior.
 | ------------------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | `LYCHEE_CONFIG`                | `.github/config/lychee.toml`                                         | Path to the lychee config file                                       |
 | `LYCHEE_CONFIG_CHANGE_PATTERN` | `^(\.github/config/lychee\.toml\|\.mise/tasks/lint/.*\|mise\.toml)$` | Regular expression for files whose change triggers a full link check |
+| `LYCHEE_SKIP_GITHUB_REMAPS`    | unset                                                                | Set to `true` to disable all GitHub URL remaps                       |
 
 <!-- editorconfig-checker-enable -->
 

--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -1,0 +1,22 @@
+# Link remap smoke test
+
+These links exercise the GitHub URL remap rules in `tasks/lint/links.sh`.
+On PR branches, lychee rewrites `blob/main/` URLs to the PR branch —
+these links verify that each remap rule works correctly during CI.
+
+## Line-number anchors (`#L123`) — fragment stripped, file checked on PR branch
+
+- [README.md#L1](https://github.com/grafana/flint/blob/main/README.md#L1)
+- [links.sh#L6](https://github.com/grafana/flint/blob/main/tasks/lint/links.sh#L6)
+
+## Section fragments (`#section`) — remapped to raw.githubusercontent.com
+
+- [CHANGELOG.md heading](https://github.com/grafana/flint/blob/main/CHANGELOG.md#changelog)
+
+## Non-fragment blob URLs — remapped to PR branch
+
+- [LICENSE](https://github.com/grafana/flint/blob/main/LICENSE)
+
+## Tree URLs — remapped to PR branch
+
+- [tasks/lint directory](https://github.com/grafana/flint/tree/main/tasks/lint)


### PR DESCRIPTION
## Summary

- Add ordered remaps in `build_remap_args()` for GitHub `/blob/` and `/tree/` URLs with line-number anchors (`#L123`) and other fragments (`#section`)
- Line-number anchors are stripped (they're JS-rendered and unverifiable by lychee); other fragments are remapped to `raw.githubusercontent.com` as a workaround for [lychee#1729](https://github.com/lycheeverse/lychee/issues/1729)
- Consuming repos no longer need custom `remap` rules in `lychee.toml` for these patterns
- Add `LYCHEE_SKIP_GITHUB_REMAPS=true` opt-out env var

## Context

GitHub blob URLs with line-number anchors (`#L6`) are JavaScript-rendered and can't be verified by lychee (which fetches static HTML). When the existing branch remap rewrites `blob/main/` → `blob/<pr-branch>/`, these URLs fail fragment checking.

Since lychee uses **first-match-wins** (no chaining), config file remaps never run after flint's CLI `--remap` matches. The fix belongs here in `build_remap_args()`.

### Remap order (first-match-wins)

For `/blob/` URLs:
1. **Line-number anchors** (`#L123`): strip fragment, check file on base branch
2. **Other fragment URLs** (`#section`): remap to `raw.githubusercontent.com` + head branch
3. **Non-fragment URLs**: branch-remap only (existing behavior)

For `/tree/` URLs: rules 1 and 3 only (no raw remap needed).

## Test plan

- [ ] Run `mise run lint:links --full` in a consuming repo (e.g. grafana-opentelemetry-java) with a `#L6` link
- [ ] Verify the link passes without custom `remap` rules in `lychee.toml`
- [ ] CI passes