### PR TITLE
ci(release-please): add footer to release PRs with CI trigger reminder

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "simple",
+	"pull-request-footer": "> [!IMPORTANT]\n> Close and reopen this PR to trigger CI checks.",
 	"packages": {
 		".": {
 			"changelog-path": "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Adds a `pull-request-footer` to release-please config with an `[!IMPORTANT]` callout reminding maintainers to close and reopen the PR to trigger CI checks

## Test plan
- [ ] Verify the next release-please PR includes the footer text