### PR TITLE
docs: update README URLs to v0.6.0 and add Renovate rule to keep them current

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,4 +1,9 @@
 {
+  "README.md": {
+    "regex": [
+      "grafana/flint"
+    ]
+  },
   "mise.toml": {
     "mise": [
       "lychee",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,13 @@
       managerFilePatterns: ["/^mise\\.toml$/"],
       matchStrings: ['# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION="?(?<currentValue>[^@"]+?)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"?\\s'],
     },
+    {
+      customType: "regex",
+      description: "Update SHA-pinned raw.githubusercontent.com URLs in README.md",
+      managerFilePatterns: ["/^README\\.md$/"],
+      matchStrings: ["https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentDigest>[a-f0-9]{40})/.*#\\s*(?<currentValue>v\\S+)"],
+      datasourceTemplate: "github-tags",
+    },
   ],
   packageRules: [
     {

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ pinned to the commit SHA of a release tag with a version comment:
 # Pick the tasks you need from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/30090d5540807f330a94420ad11b57ba93eaaa84/tasks/lint/super-linter.sh" # v0.3.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/super-linter.sh" # v0.6.0
 [tasks."lint:links"]
 description = "Check for broken links in changed files + all local links"
-file = "https://raw.githubusercontent.com/grafana/flint/30090d5540807f330a94420ad11b57ba93eaaa84/tasks/lint/links.sh" # v0.3.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/links.sh" # v0.6.0
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/30090d5540807f330a94420ad11b57ba93eaaa84/tasks/lint/renovate-deps.py" # v0.3.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/renovate-deps.py" # v0.6.0
 ```
 
 <!-- editorconfig-checker-enable -->
@@ -379,10 +379,10 @@ Breaking changes will be documented in [CHANGELOG.md](CHANGELOG.md)
 and will result in a major version bump.
 
 **Always pin to a specific commit SHA** in your `mise.toml` file
-URLs with a version comment (e.g., `# v0.3.0`). Never reference
+URLs with a version comment (e.g., `# v0.6.0`). Never reference
 `main` directly as it may contain unreleased breaking changes. To
 find the commit SHA for a release tag, run
-`git rev-parse v0.3.0`.
+`git rev-parse v0.6.0`.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- Update example task URLs in README from v0.3.0 (`30090d5...`) to v0.6.0 (`5bb3726...`)
- Add a Renovate custom manager to `.github/renovate.json5` that matches `raw.githubusercontent.com` URLs in `README.md`, so they get bumped automatically after future releases
- Update `renovate-tracked-deps.json` to reflect the new manager

## Test plan

- [x] `mise run lint` passes
- [ ] Verify Renovate recognizes the new custom manager (check Dependency Dashboard after merge)