### PR TITLE
fix(release-please): fix footer not appearing on release PRs

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "simple",
+	"separate-pull-requests": false,
 	"pull-request-footer": "> [!IMPORTANT]\n> Close and reopen this PR to trigger CI checks.",
 	"packages": {
 		".": {


### PR DESCRIPTION
## Summary
- `pull-request-footer` was not being applied to release PRs because
  release-please defaults `separatePullRequests` to `true` for
  single-package configs, which skips the Merge plugin responsible for
  applying the footer
- Setting `separate-pull-requests: false` forces the Merge plugin to run

## Context
- Same workaround applied to prometheus/client_java in
  https://github.com/prometheus/client_java/pull/1902

## Test plan
- [ ] After merging, verify the next release PR includes the footer