### PR TITLE
chore(release-please): remove unnecessary separate-pull-requests workaround

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "simple",
-	"separate-pull-requests": false,
 	"pull-request-footer": "> [!IMPORTANT]\n> Close and reopen this PR to trigger CI checks.",
 	"packages": {
 		".": {


### PR DESCRIPTION
## Summary
- Remove `separate-pull-requests: false` added in #40
- That workaround is only needed for Java snapshot PRs (upstream bug:
  https://github.com/googleapis/release-please/pull/2685)
- Flint uses `release-type: simple`, so the footer works without it