### PR TITLE
fix: use remap instead of exclude for issue comment anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,12 @@ two patterns that affect ALL GitHub URLs (any repository):
   JS-rendered line-number fragment is skipped. This means
   consuming repos don't need to exclude these in their
   `lychee.toml`.
-- **Issue comment anchors** (`#issuecomment-*`): Excluded
-  entirely. These are JS-rendered and cannot be verified by
-  lychee.
+- **Issue comment anchors** (`#issuecomment-*`): The fragment
+  is stripped so the issue/PR page is still checked, but the
+  JS-rendered comment anchor is skipped.
 
 Set `LYCHEE_SKIP_GITHUB_REMAPS=true` to disable all GitHub-specific
-remaps and exclusions as an escape hatch if they cause unexpected
-behavior.
+remaps as an escape hatch if they cause unexpected behavior.
 
 **Environment variables:**
 

--- a/tasks/lint/links.sh
+++ b/tasks/lint/links.sh
@@ -106,7 +106,11 @@ build_remap_args() {
 #     lychee cannot verify them. We strip the fragment so the file
 #     itself is still checked.
 #   - Issue comment anchors (#issuecomment-*): rendered by JavaScript,
-#     lychee cannot verify them.
+#     lychee cannot verify them. The fragment is stripped so the
+#     issue/PR page itself is still checked.
+#
+# We use --remap (not --exclude) because CLI --exclude overrides
+# config file excludes in lychee, rather than merging with them.
 #
 # Set LYCHEE_SKIP_GITHUB_REMAPS=true to skip these (same escape hatch
 # as for the repo-specific remaps above).
@@ -118,9 +122,13 @@ build_global_github_args() {
 	# shellcheck disable=SC2016 # single quotes are intentional: these are regex capture groups, not shell vars
 	echo '^https://github.com/([^/]+/[^/]+)/blob/([^/]+)/(.*?)#L[0-9]+.*$ https://github.com/$1/blob/$2/$3'
 
-	# Exclude issue comment anchors (JS-rendered, not in static HTML)
-	echo "--exclude"
-	echo '^https://github.com/.*#issuecomment-.*$'
+	# Strip issue comment anchors (JS-rendered, not in static HTML).
+	# The issue page is still checked, just not the fragment.
+	# We use --remap instead of --exclude because CLI --exclude
+	# overrides (rather than merges with) config file excludes.
+	echo "--remap"
+	# shellcheck disable=SC2016 # single quotes are intentional
+	echo '^https://github.com/([^/]+/[^/]+)/(issues|pull)/([0-9]+)#issuecomment-.*$ https://github.com/$1/$2/$3'
 }
 
 run_lychee() {

--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -33,9 +33,10 @@ but the JS-rendered fragment is skipped.
 <!-- editorconfig-checker-enable -->
 - [lychee main.rs#L1](https://github.com/lycheeverse/lychee/blob/master/lychee-bin/src/main.rs#L1)
 
-## Issue comment anchors — excluded globally
+## Issue comment anchors — fragment stripped globally
 
 Issue comment anchors are rendered by JavaScript and cannot be
-verified by lychee.
+verified by lychee. The fragment is stripped so the issue/PR page
+is still checked.
 
 - [example issue comment](https://github.com/grafana/flint/issues/1#issuecomment-1)


### PR DESCRIPTION
## Summary

Fixes the lint failure in #41 (release-please PR).

CLI `--exclude` overrides (rather than merges with) config file excludes in lychee. The `--exclude` added in #56 for `#issuecomment-` URLs caused the config file's `exclude` patterns (like the `compare/` URL exclusion) to be ignored.

Fix: switch to `--remap` which strips the `#issuecomment-` fragment while still checking the issue/PR page itself.

## Test plan
- [ ] CI passes (the release-please PR #41 should also pass after this merges)