### PR TITLE
docs: add lychee config cleanup note for lint:links adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,24 +247,22 @@ remaps as an escape hatch if they cause unexpected behavior.
 **Lychee config cleanup:**
 
 When adopting `lint:links`, you can remove the following entries
-from your `lychee.toml` because flint handles them at runtime via
-`--remap` arguments:
+from your `lychee.toml` because flint handles them at runtime
+via `--remap` arguments:
 
-- **GitHub blob remap for lychee#1729** (e.g.
-  `"https://github.com/(.*?)/(.*?)/blob/(.*?)/(.*#.*)$ https://raw.githubusercontent.com/$1/$2/$3/$4"`)
-  — flint remaps fragment URLs to `raw.githubusercontent.com` for
-  the current PR's head branch, and strips line-number anchors
-  globally.
-- **`#issuecomment-*` excludes** (e.g.
-  `'^https://github.com/.*#issuecomment-.*$'`) — flint strips the
-  fragment via remap so the issue/PR page is still checked.
-- **`#L\d+` line-number excludes** (e.g.
-  `'^https://github.com/.+/blob/.+#L\d+'`) — flint strips the
-  fragment via remap so the file is still checked.
+- **GitHub blob/fragment remap for
+  [lychee#1729](https://github.com/lycheeverse/lychee/issues/1729)**
+  — flint remaps fragment URLs to `raw.githubusercontent.com`
+  for the current PR's head branch, and strips line-number
+  anchors globally.
+- **`#issuecomment-*` excludes** — flint strips the fragment
+  via remap so the issue/PR page is still checked.
+- **`#L\d+` line-number excludes** — flint strips the fragment
+  via remap so the file is still checked.
 
 Note: flint uses `--remap` (not `--exclude`) for these because
-lychee's CLI `--exclude` flags override config file excludes rather
-than merging with them.
+lychee's CLI `--exclude` flags override config file excludes
+rather than merging with them.
 
 **Environment variables:**
 


### PR DESCRIPTION
## Summary

Add a "Lychee config cleanup" section to the `lint:links` docs listing which `lychee.toml` entries can be removed when adopting flint, because flint handles them at runtime via `--remap`.

**Motivation:** When adopting flint in [opentelemetry-java-instrumentation#16270](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/16270), I initially kept (and even added) lychee config entries that flint already handles — the existing docs explain *what* flint does but don't explicitly tell adopters *what they can remove* from their lychee config.

## Entries documented for removal

- GitHub blob remap workaround for lychee#1729
- `#issuecomment-*` excludes
- `#L\d+` line-number anchor excludes