### PR TITLE
test: normalize markdownlint-cli2 version banner in e2e snapshots

### DIFF
--- a/tests/cases/markdownlint-cli2/failure/test.toml
+++ b/tests/cases/markdownlint-cli2/failure/test.toml
@@ -3,11 +3,11 @@ args = "run --full markdownlint-cli2"
 exit = 1
 stderr = '''
 [markdownlint-cli2]
-markdownlint-cli2 v0.17.2 (markdownlint v0.37.4)
+markdownlint-cli2 <VERSION>
 Finding: <REPO>/README.md
 Linting: 1 file(s)
 Summary: 1 error(s)
-README.md:3:26 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 3]
+README.md:3:26 error MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 3]
 
 flint: 1 check failed (markdownlint-cli2)
 💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.

--- a/tests/cases/markdownlint-cli2/failure/test.toml
+++ b/tests/cases/markdownlint-cli2/failure/test.toml
@@ -7,7 +7,7 @@ markdownlint-cli2 <VERSION>
 Finding: <REPO>/README.md
 Linting: 1 file(s)
 Summary: 1 error(s)
-README.md:3:26 error MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 3]
+README.md:3:26 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 3]
 
 flint: 1 check failed (markdownlint-cli2)
 💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -271,12 +271,12 @@ fn run_case(case: &Path, name: &str, update: bool) {
     let repo_canonical_str = canonical_repo_path(repo.path());
     let normalize =
         |s: String| -> String { normalize_output(s, repo_str.as_ref(), &repo_canonical_str) };
-    let stderr = normalize_timing(&strip_ansi(&normalize(
+    let stderr = normalize_tool_versions(&normalize_timing(&strip_ansi(&normalize(
         String::from_utf8_lossy(&out.stderr).into_owned(),
-    )));
-    let stdout = normalize_timing(&strip_ansi(&normalize(
+    ))));
+    let stdout = normalize_tool_versions(&normalize_timing(&strip_ansi(&normalize(
         String::from_utf8_lossy(&out.stdout).into_owned(),
-    )));
+    ))));
 
     if update {
         write_test_toml(
@@ -388,6 +388,17 @@ fn normalize_timing(s: &str) -> String {
     // Biome summary line: "Checked N file(s) in 1234µs. No fixes applied."
     let re2 = Regex::new(r"Checked \d+ files? in \d+(?:\.\d+)?(?:µs|ms|s)\.").unwrap();
     re2.replace_all(&s, "Checked N file(s) in Xµs.")
+        .into_owned()
+}
+
+/// Replaces tool version banners with a stable `<VERSION>` placeholder so
+/// snapshots don't need updating on every dependency bump.
+fn normalize_tool_versions(s: &str) -> String {
+    use regex::Regex;
+    // markdownlint-cli2 vX.Y.Z (markdownlint vA.B.C)
+    let re = Regex::new(r"markdownlint-cli2 v\d+\.\d+\.\d+ \(markdownlint v\d+\.\d+\.\d+\)")
+        .unwrap();
+    re.replace_all(s, "markdownlint-cli2 <VERSION>")
         .into_owned()
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -396,8 +396,8 @@ fn normalize_timing(s: &str) -> String {
 fn normalize_tool_versions(s: &str) -> String {
     use regex::Regex;
     // markdownlint-cli2 vX.Y.Z (markdownlint vA.B.C)
-    let re = Regex::new(r"markdownlint-cli2 v\d+\.\d+\.\d+ \(markdownlint v\d+\.\d+\.\d+\)")
-        .unwrap();
+    let re =
+        Regex::new(r"markdownlint-cli2 v\d+\.\d+\.\d+ \(markdownlint v\d+\.\d+\.\d+\)").unwrap();
     re.replace_all(s, "markdownlint-cli2 <VERSION>")
         .into_owned()
 }


### PR DESCRIPTION
## Summary

- Add `normalize_tool_versions` to `e2e.rs` — replaces the `markdownlint-cli2 vX.Y.Z (markdownlint vA.B.C)` banner with `<VERSION>` so snapshots don't need updating on every version bump
- Update `markdownlint-cli2/failure` snapshot: use `<VERSION>` placeholder and capture the v0.22.0 format change (`error ` prefix on rule violations)

Unblocks renovate PR #154 (markdownlint-cli2 0.17.2 → 0.22.0).

## Test plan

- [ ] CI passes