### PR TITLE
fix(release): add workflow_dispatch to retrigger for existing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,9 @@ jobs:
           tar: unix
           zip: windows
           checksum: sha256
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.20.0)"
+        description: "Bare tag name to release (e.g. v0.20.0, not refs/tags/v0.20.0)"
         required: true
 
 permissions: {}
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Build and upload
@@ -55,7 +55,7 @@ jobs:
           tar: unix
           zip: windows
           checksum: sha256
-          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.20.0)"
+        required: true
 
 permissions: {}
 
@@ -37,6 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Build and upload
@@ -51,6 +57,7 @@ jobs:
           checksum: sha256
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger with a `tag` input to the release workflow
- Passes the tag as `ref` to both `actions/checkout` and `upload-rust-binary-action` (via `GITHUB_REF` override)
- No change to the normal push-triggered flow

## Why

The `v0.20.0` release workflow failed because the tag was `flint-v0.20.0` (release-please bug, fixed in #166) and the release had to be created manually. Due to tag protection rules and the immutable-releases policy, there was no way to retrigger the workflow. This adds an escape hatch for that situation.