### PR TITLE
fix(registry): add --tests to cargo-clippy, add test coverage

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -349,10 +349,10 @@ fn compute_desired_tools(
         }
         if categories.contains(&check.category) {
             let entry = by_key.entry(key.to_string()).or_default();
-            if let Some(comp) = check.mise_install_components {
-                if !entry.contains(&comp) {
-                    entry.push(comp);
-                }
+            if let Some(comp) = check.mise_install_components
+                && !entry.contains(&comp)
+            {
+                entry.push(comp);
             }
         }
     }

--- a/src/linters/renovate_deps.rs
+++ b/src/linters/renovate_deps.rs
@@ -277,6 +277,7 @@ mod tests {
         format!(r#"{{"msg":"Extracted dependencies","packageFiles":{config_json}}}"#).into_bytes()
     }
 
+    #[allow(clippy::type_complexity)]
     fn dep_map(entries: &[(&str, &[(&str, &[&str])])]) -> DepMap {
         entries
             .iter()

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -498,12 +498,16 @@ fn check_biome_format() -> Check {
 }
 
 fn check_cargo_clippy() -> Check {
-    Check::project("cargo-clippy", "cargo clippy -q --tests -- -D warnings", &["*.rs"])
-        .fix("cargo clippy -q --tests --fix --allow-dirty --allow-staged -- -D warnings")
-        .mise_tool("rust")
-        .install_components("clippy")
-        .desc("Lint Rust code; runs on all .rs files, not just changed")
-        .lang()
+    Check::project(
+        "cargo-clippy",
+        "cargo clippy -q --tests -- -D warnings",
+        &["*.rs"],
+    )
+    .fix("cargo clippy -q --tests --fix --allow-dirty --allow-staged -- -D warnings")
+    .mise_tool("rust")
+    .install_components("clippy")
+    .desc("Lint Rust code; runs on all .rs files, not just changed")
+    .lang()
 }
 
 fn check_cargo_fmt() -> Check {
@@ -893,7 +897,7 @@ mod tests {
     #[test]
     fn all_registry_binaries_found() {
         let registry = builtin();
-        let mise_tools = read_mise_tools(Path::new(env!("CARGO_MANIFEST_DIR")));
+        let _mise_tools = read_mise_tools(Path::new(env!("CARGO_MANIFEST_DIR")));
 
         let not_found: Vec<&str> = registry
             .iter()
@@ -1008,7 +1012,7 @@ mod tests {
         };
         let separator: Vec<String> = widths.iter().map(|&w| "-".repeat(w)).collect();
         let sep_row = format!("| {} |", separator.join(" | "));
-        let header_strs: Vec<&str> = headers.iter().copied().collect();
+        let header_strs: Vec<&str> = headers.to_vec();
 
         let mut lines = vec![
             generated_comment.to_string(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -498,8 +498,8 @@ fn check_biome_format() -> Check {
 }
 
 fn check_cargo_clippy() -> Check {
-    Check::project("cargo-clippy", "cargo clippy -q -- -D warnings", &["*.rs"])
-        .fix("cargo clippy -q --fix --allow-dirty --allow-staged -- -D warnings")
+    Check::project("cargo-clippy", "cargo clippy -q --tests -- -D warnings", &["*.rs"])
+        .fix("cargo clippy -q --tests --fix --allow-dirty --allow-staged -- -D warnings")
         .mise_tool("rust")
         .install_components("clippy")
         .desc("Lint Rust code; runs on all .rs files, not just changed")

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -500,10 +500,10 @@ fn check_biome_format() -> Check {
 fn check_cargo_clippy() -> Check {
     Check::project(
         "cargo-clippy",
-        "cargo clippy -q --tests -- -D warnings",
+        "cargo clippy -q --all-targets -- -D warnings",
         &["*.rs"],
     )
-    .fix("cargo clippy -q --tests --fix --allow-dirty --allow-staged -- -D warnings")
+    .fix("cargo clippy -q --all-targets --fix --allow-dirty --allow-staged -- -D warnings")
     .mise_tool("rust")
     .install_components("clippy")
     .desc("Lint Rust code; runs on all .rs files, not just changed")

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -897,7 +897,7 @@ mod tests {
     #[test]
     fn all_registry_binaries_found() {
         let registry = builtin();
-        let _mise_tools = read_mise_tools(Path::new(env!("CARGO_MANIFEST_DIR")));
+        let mise_tools = read_mise_tools(Path::new(env!("CARGO_MANIFEST_DIR")));
 
         let not_found: Vec<&str> = registry
             .iter()

--- a/tests/cases/cargo-clippy/failure-in-tests/files/Cargo.toml
+++ b/tests/cases/cargo-clippy/failure-in-tests/files/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test"
+version = "0.1.0"
+edition = "2024"

--- a/tests/cases/cargo-clippy/failure-in-tests/files/mise.toml
+++ b/tests/cases/cargo-clippy/failure-in-tests/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+rust = "latest"

--- a/tests/cases/cargo-clippy/failure-in-tests/files/src/lib.rs
+++ b/tests/cases/cargo-clippy/failure-in-tests/files/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn add(x: i32, y: i32) -> i32 {
+    x + y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unused_var() {
+        let result = add(1, 2);
+    }
+}

--- a/tests/cases/cargo-clippy/failure-in-tests/test.toml
+++ b/tests/cases/cargo-clippy/failure-in-tests/test.toml
@@ -1,0 +1,19 @@
+[expected]
+args = "run --full cargo-clippy"
+exit = 1
+stderr = '''
+[cargo-clippy]
+error: unused variable: `result`
+  --> src/lib.rs:11:13
+   |
+11 |         let result = add(1, 2);
+   |             ^^^^^^ help: if this is intentional, prefix it with an underscore: `_result`
+   |
+   = note: `-D unused-variables` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_variables)]`
+
+error: could not compile `test` (lib test) due to 1 previous error
+
+flint: 1 check failed (cargo-clippy)
+💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
+'''

--- a/tests/cases/cargo-clippy/failure/test.toml
+++ b/tests/cases/cargo-clippy/failure/test.toml
@@ -12,6 +12,7 @@ error: equal expressions as operands to `==`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#eq_op
   = note: `#[deny(clippy::eq_op)]` on by default
 
+error: could not compile `test` (lib) due to 1 previous error
 error: could not compile `test` (lib test) due to 1 previous error
 
 flint: 1 check failed (cargo-clippy)

--- a/tests/cases/cargo-clippy/failure/test.toml
+++ b/tests/cases/cargo-clippy/failure/test.toml
@@ -12,7 +12,7 @@ error: equal expressions as operands to `==`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#eq_op
   = note: `#[deny(clippy::eq_op)]` on by default
 
-error: could not compile `test` (lib) due to 1 previous error
+error: could not compile `test` (lib test) due to 1 previous error
 
 flint: 1 check failed (cargo-clippy)
 💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -346,26 +346,26 @@ fn write_test_toml(path: &Path, cfg: &toml::Value, exit: i32, stderr: &str, stdo
         }
     }
 
-    if let Some(env) = cfg.get("env").and_then(|v| v.as_table()) {
-        if !env.is_empty() {
-            out += "\n\n[env]\n";
-            for (k, v) in env {
-                if let Some(s) = v.as_str() {
-                    out += &format!("{k} = \"{}\"\n", toml_escape(s));
-                }
+    if let Some(env) = cfg.get("env").and_then(|v| v.as_table())
+        && !env.is_empty()
+    {
+        out += "\n\n[env]\n";
+        for (k, v) in env {
+            if let Some(s) = v.as_str() {
+                out += &format!("{k} = \"{}\"\n", toml_escape(s));
             }
         }
     }
 
     // Serialize as multiline literal strings so shell scripts stay readable.
     // TOML trims the first newline after ''', so '''\n{s}''' roundtrips cleanly.
-    if let Some(bins) = cfg.get("fake_bins").and_then(|v| v.as_table()) {
-        if !bins.is_empty() {
-            out += "\n[fake_bins]\n";
-            for (k, v) in bins {
-                if let Some(s) = v.as_str() {
-                    out += &format!("{k} = '''\n{s}'''\n");
-                }
+    if let Some(bins) = cfg.get("fake_bins").and_then(|v| v.as_table())
+        && !bins.is_empty()
+    {
+        out += "\n[fake_bins]\n";
+        for (k, v) in bins {
+            if let Some(s) = v.as_str() {
+                out += &format!("{k} = '''\n{s}'''\n");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `--tests` to `cargo-clippy` registry entry — test code was previously unlinted
- Apply resulting clippy fixes (unused var, if-let chains, `type_complexity` allow)
- Add `failure-in-tests` e2e case to verify test code linting works
- Fix existing `failure` fixture: `(lib)` → `(lib test)` in error message (changed by `--tests`)

Motivated by a bug caught immediately: missing arg in test call sites went undetected until CI.

## Test plan

- [ ] CI passes (Linux, macOS, Windows)