### PR TITLE
fix(release): use correct template variable in pr_body

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,7 @@
 [workspace]
 git_release_draft = true
 pr_body = """
-{{ changelog }}
+{% for release in releases %}{{ release.changelog }}{% endfor %}
 
 > [!IMPORTANT]
 > Close and reopen this PR to trigger CI checks.


### PR DESCRIPTION
## Summary

- `{{ changelog }}` is only valid in `git_release_body`, not `pr_body`
- release-plz bails with `Variable 'changelog' not found in context while rendering 'pr_body'` ([run](https://github.com/grafana/flint/actions/runs/24516239267/job/71660975290))
- Fix: use `release.changelog` inside a releases loop

## Test plan

- [ ] Merge and verify release-plz "Release PR" job succeeds on next push to main