### PR TITLE
fix(release): disable crates.io publishing

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,6 @@
 [workspace]
 git_release_draft = true
+publish = false
 pr_body = """
 {% for release in releases %}{{ release.changelog }}{% endfor %}
 


### PR DESCRIPTION
## Summary

- release-plz tries to publish to crates.io by default
- Fails with "no token found" on every push to main ([run](https://github.com/grafana/flint/actions/runs/24522879792/job/71685158788))
- Flint distributes via GitHub releases only — add `publish = false`