### PR TITLE
fix(release): sequence release-pr after release and trigger binary build

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,9 @@ jobs:
     # Runs on every push to main. Keeps an open PR that bumps Cargo.toml version
     # and updates CHANGELOG.md based on conventional commits since the last release.
     # Merging this PR triggers the release job above.
+    # Depends on release so the new git tag exists before we compute the next version.
     name: Release PR
+    needs: [release]
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'grafana/flint' }}
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,12 +11,13 @@ permissions: {}
 jobs:
   release:
     # Runs on every push to main. If the release PR was just merged (i.e. Cargo.toml
-    # version was bumped), creates a git tag and a draft GitHub release. The release.yml
-    # workflow then picks up the tag, builds binaries, and publishes the release.
+    # version was bumped), creates a git tag and a draft GitHub release, then triggers
+    # release.yml to build platform binaries and publish the release.
     name: Release
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'grafana/flint' }}
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,10 +25,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        id: release-plz
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger binary release
+        if: ${{ steps.release-plz.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          gh workflow run release.yml
+          -f tag=${{ fromJSON(steps.release-plz.outputs.releases)[0].tag }}
 
   release-pr:
     # Runs on every push to main. Keeps an open PR that bumps Cargo.toml version


### PR DESCRIPTION
## Summary

- Release PR and Release jobs ran concurrently — Release PR computed the next version before the new tag existed, using the full commit history as changelog
- Fix: `needs: [release]` ensures the tag is created before the next release PR is computed
- `GITHUB_TOKEN`-created tags don't fire `push: tags:` triggers in other workflows — same limitation as release-please
- Fix: dispatch `release.yml` directly from the release job when a release is created (same pattern as prometheus/client_java)

## Test plan

- [ ] Merge and verify the next release PR only contains commits since the last tag
- [ ] Verify `release.yml` triggers automatically after the next release PR is merged