### PR TITLE
feat: migrate shfmt & auto-add node prereq for npm: tools

### DIFF
--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -98,16 +98,17 @@ fn add_to_extends(content: &str, entry: &str) -> Result<String> {
     }
 }
 
-/// Runs `mise use --pin <key>@latest` in the project directory to add a tool
-/// with a pinned version. Returns `true` if the key was written to the config
-/// (checked by re-reading the file), ignoring non-zero exit codes that arise
-/// from post-write steps like shim rebuilds failing in restricted environments.
-fn pin_tool_via_mise(project_root: &Path, key: &str) -> bool {
+/// Runs `mise use --pin <key>@<version>` in the project directory to add a tool
+/// with a pinned version (mise resolves `latest`/`lts` to a concrete version at
+/// write time). Returns `true` if the key was written to the config (checked by
+/// re-reading the file), ignoring non-zero exit codes that arise from post-write
+/// steps like shim rebuilds failing in restricted environments.
+fn pin_tool_via_mise(project_root: &Path, key: &str, version: &str) -> bool {
     let mise_path = project_root.join("mise.toml");
     let before = std::fs::read_to_string(&mise_path).unwrap_or_default();
 
     let _ = Command::new("mise")
-        .args(["use", "--pin", &format!("{key}@latest")])
+        .args(["use", "--pin", &format!("{key}@{version}")])
         .current_dir(project_root)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -116,6 +117,46 @@ fn pin_tool_via_mise(project_root: &Path, key: &str) -> bool {
     // Success = the key is now present in the config (regardless of exit code).
     let after = std::fs::read_to_string(&mise_path).unwrap_or_default();
     after != before && parse_tool_keys(&after).contains(key)
+}
+
+/// True when `[tools]` contains at least one `npm:*` key but no `node` entry.
+/// The npm backend needs a Node.js runtime; without an explicit pin, mise falls
+/// back to system node — may be absent, wrong version, or drift across machines.
+fn needs_node_for_npm(content: &str) -> bool {
+    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+        return false;
+    };
+    let Some(tools) = doc.get("tools").and_then(|t| t.as_table()) else {
+        return false;
+    };
+    let has_npm = tools.iter().any(|(k, _)| k.starts_with("npm:"));
+    let has_node = tools.contains_key("node");
+    has_npm && !has_node
+}
+
+/// Ensures a `node` entry exists in mise.toml when any `npm:*` backend tool is
+/// present. Prefers `mise use --pin node@lts` so the version resolves to a
+/// concrete release at write time; falls back to writing `node = "lts"` directly
+/// via toml_edit when mise isn't available.
+///
+/// Returns `true` if a `node` entry was added.
+pub(crate) fn ensure_node_for_npm(project_root: &Path) -> Result<bool> {
+    let mise_path = project_root.join("mise.toml");
+    let content = std::fs::read_to_string(&mise_path).unwrap_or_default();
+    if !needs_node_for_npm(&content) {
+        return Ok(false);
+    }
+    if pin_tool_via_mise(project_root, "node", "lts") {
+        return Ok(true);
+    }
+    // Fallback: write a soft pin so mise.toml still declares the prereq.
+    let mut doc: toml_edit::DocumentMut = content.parse().context("failed to parse mise.toml")?;
+    let tools = doc["tools"]
+        .as_table_mut()
+        .context("[tools] is not a table")?;
+    tools.insert("node", toml_edit::value("lts"));
+    std::fs::write(&mise_path, doc.to_string())?;
+    Ok(true)
 }
 
 /// Replaces obsolete tool keys in mise.toml with their modern equivalents,
@@ -164,7 +205,7 @@ pub(super) fn apply_changes(
     // upgrades, and component additions.
     let mut pinned_via_mise: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (key, _) in to_add {
-        if pin_tool_via_mise(project_root, key) {
+        if pin_tool_via_mise(project_root, key, "latest") {
             pinned_via_mise.insert(key.clone());
         } else {
             eprintln!("  warning: could not pin {key} via mise — writing \"latest\"");
@@ -661,6 +702,61 @@ pub(super) fn maybe_install_hook(project_root: &Path, yes: bool) -> Result<()> {
         crate::hook::install(project_root)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod node_prereq_tests {
+    use super::{ensure_node_for_npm, needs_node_for_npm};
+
+    // Full end-to-end ensure_node_for_npm coverage (npm-present, node-absent →
+    // node added, file modified) lives in the e2e case `general/update-adds-node`.
+    // That case drives the flint binary and exercises the real mise subprocess.
+
+    #[test]
+    fn needs_node_when_npm_key_without_node() {
+        let content = "[tools]\n\"npm:prettier\" = \"3.8.1\"\n";
+        assert!(needs_node_for_npm(content));
+    }
+
+    #[test]
+    fn no_node_needed_when_no_npm_keys() {
+        let content = "[tools]\nshellcheck = \"v0.11.0\"\n";
+        assert!(!needs_node_for_npm(content));
+    }
+
+    #[test]
+    fn no_node_needed_when_node_already_declared() {
+        let content = "[tools]\nnode = \"20\"\n\"npm:prettier\" = \"3.8.1\"\n";
+        assert!(!needs_node_for_npm(content));
+    }
+
+    #[test]
+    fn no_node_needed_when_tools_section_missing() {
+        assert!(!needs_node_for_npm(""));
+        assert!(!needs_node_for_npm("[env]\nFOO = \"bar\"\n"));
+    }
+
+    #[test]
+    fn noop_when_node_already_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mise.toml");
+        let original = "[tools]\nnode = \"20\"\n\"npm:prettier\" = \"3.8.1\"\n";
+        std::fs::write(&path, original).unwrap();
+        let added = ensure_node_for_npm(dir.path()).unwrap();
+        assert!(!added);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn noop_without_npm_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mise.toml");
+        let original = "[tools]\nshellcheck = \"v0.11.0\"\n";
+        std::fs::write(&path, original).unwrap();
+        let added = ensure_node_for_npm(dir.path()).unwrap();
+        assert!(!added);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
 }
 
 #[cfg(test)]

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -14,10 +14,10 @@ use detection::{
     build_linter_groups, detect_obsolete_keys, detect_present_patterns, parse_tool_keys,
 };
 use generation::{
-    apply_changes, apply_env_and_tasks, detect_base_branch, flint_preset, generate_flint_toml,
-    generate_lint_workflow, generate_markdownlint_config, get_existing_config_dir,
-    has_slow_selected, maybe_install_hook, patch_renovate_extends, prompt_config_dir,
-    remove_v1_tasks,
+    apply_changes, apply_env_and_tasks, detect_base_branch, ensure_node_for_npm, flint_preset,
+    generate_flint_toml, generate_lint_workflow, generate_markdownlint_config,
+    get_existing_config_dir, has_slow_selected, maybe_install_hook, patch_renovate_extends,
+    prompt_config_dir, remove_v1_tasks,
 };
 use ui::{interactive_select_linters, select_categories_arrow};
 
@@ -251,6 +251,11 @@ Add and stage your source files before running init so the detection is accurate
         )?;
     }
 
+    let node_added = ensure_node_for_npm(project_root)?;
+    if node_added {
+        println!("  added node (LTS) — required by npm: backend tools");
+    }
+
     let v1 = remove_v1_tasks(&mise_path)?;
     for key in &v1.removed_tasks {
         println!("  removing v1 task {key}");
@@ -290,6 +295,7 @@ Add and stage your source files before running init so the detection is accurate
         .unwrap_or(false);
 
     if !tools_changed
+        && !node_added
         && v1.removed_tasks.is_empty()
         && !v1.removed_renovate_env
         && !meta_changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,11 +145,15 @@ async fn main() -> Result<()> {
         SubCommand::Update => {
             let replaced =
                 init::generation::replace_obsolete_keys(&project_root, registry::OBSOLETE_KEYS)?;
-            if replaced.is_empty() {
+            let node_added = init::generation::ensure_node_for_npm(&project_root)?;
+            if replaced.is_empty() && !node_added {
                 println!("flint: mise.toml is up to date");
             } else {
                 for (old, new) in &replaced {
                     println!("  replaced {old:?} → {new:?}");
+                }
+                if node_added {
+                    println!("  added node (LTS) — required by npm: backend tools");
                 }
             }
         }

--- a/src/registry/obsolete.rs
+++ b/src/registry/obsolete.rs
@@ -14,6 +14,11 @@ pub const OBSOLETE_KEYS: &[(&str, &str)] = &[
         "github:google/google-java-format",
     ),
     ("ubi:pinterest/ktlint", "github:pinterest/ktlint"),
+    // Bare `shfmt` resolves via aqua registry, which is broken in current mise
+    // releases. `github:mvdan/sh` works — paired with `versioned_bin("shfmt_{version}")`
+    // in the registry. Remove this entry once aqua registry is fixed upstream
+    // (tracked in flint#175).
+    ("shfmt", "github:mvdan/sh"),
 ];
 
 /// Checks whether any obsolete tool keys are present in `mise_tools`.

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -21,6 +21,16 @@ fn find_obsolete_key_returns_none_for_clean_tools() {
     assert_eq!(find_obsolete_key(&tools), None);
 }
 
+#[test]
+fn find_obsolete_key_detects_bare_shfmt() {
+    let mut tools = HashMap::new();
+    tools.insert("shfmt".to_string(), "v3.12.0".to_string());
+    assert_eq!(
+        find_obsolete_key(&tools),
+        Some(("shfmt", "github:mvdan/sh"))
+    );
+}
+
 /// If any entry for a bin_name declares a version_range, every entry for that
 /// bin_name must declare one. A mix of ranged and unranged entries for the same
 /// binary is ambiguous — it would be impossible to guarantee exactly one activates.

--- a/tests/cases/general/list/files/mise.toml
+++ b/tests/cases/general/list/files/mise.toml
@@ -2,7 +2,7 @@
 lychee = "0.22.0"
 "npm:renovate" = "43.92.1"
 shellcheck = "v0.11.0"
-shfmt = "v3.12.0"
+"github:mvdan/sh" = "v3.13.1"
 actionlint = "1.7.10"
 editorconfig-checker = "v3.6.1"
 "npm:markdownlint-cli2" = "0.17.2"

--- a/tests/cases/general/update-adds-node/files/mise.toml
+++ b/tests/cases/general/update-adds-node/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"npm:prettier" = "3.8.1"

--- a/tests/cases/general/update-adds-node/test.toml
+++ b/tests/cases/general/update-adds-node/test.toml
@@ -1,0 +1,4 @@
+[expected]
+args = "update"
+exit = 0
+stdout = "  added node (LTS) — required by npm: backend tools\n"

--- a/tests/cases/general/update-no-op/files/mise.toml
+++ b/tests/cases/general/update-no-op/files/mise.toml
@@ -1,3 +1,4 @@
 [tools]
+node = "24.14.1"
 "npm:markdownlint-cli2" = "0.17.2"
 shellcheck = "v0.11.0"

--- a/tests/cases/general/update-obsolete-key/files/mise.toml
+++ b/tests/cases/general/update-obsolete-key/files/mise.toml
@@ -1,3 +1,4 @@
 [tools]
+node = "24.14.1"
 "npm:markdownlint-cli" = "0.39.0"
 shellcheck = "v0.11.0"

--- a/tests/cases/general/update-obsolete-key/test.toml
+++ b/tests/cases/general/update-obsolete-key/test.toml
@@ -6,6 +6,7 @@ stdout = "  replaced \"npm:markdownlint-cli\" → \"npm:markdownlint-cli2\"\n"
 [expected.files]
 "mise.toml" = '''
 [tools]
+node = "24.14.1"
 shellcheck = "v0.11.0"
 "npm:markdownlint-cli2" = "0.39.0"
 '''


### PR DESCRIPTION
Stacked on #187.

Two small migrations derived from the flint-v2 design todos:

### 1. `shfmt` → `github:mvdan/sh`

Bare `shfmt` resolves via aqua registry, which is broken in current
mise releases. `github:mvdan/sh` works (paired with the existing
`versioned_bin("shfmt_{version}")` wiring). Adds the mapping to
`OBSOLETE_KEYS` so `flint update` rewrites existing mise.toml files
non-interactively. Remove once [jdx/mise#9191](https://github.com/jdx/mise/pull/9191) ships (v2026.4.17+) and #175 lands the bare `shfmt` restoration via `aqua:mvdan/sh`.

### 2. Auto-add `node` prereq for `npm:` backend tools

npm-backed tools (prettier, biome, markdownlint-cli2, renovate) need
the `npm` command, which needs a Node.js runtime. Without an explicit
`node` entry, mise falls back to system node — may be absent, wrong
version, or drift across machines, breaking the "reproducible lint
environment" promise.

`flint init` and `flint update` now detect this and pin `node@lts`
via `mise use --pin` (resolves to a concrete version at write time).

## Test plan
- [ ] Unit tests pass (`cargo test --bin flint`)
- [ ] E2E tests pass (`cargo test --test e2e`)
- [ ] Run `flint update` on a repo with `npm:prettier` but no `node` → adds node
- [ ] Run `flint update` on a repo with bare `shfmt` → rewritten to `github:mvdan/sh`