### PR TITLE
docs: clarify that flint init works with existing mise.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Add `flint` to your repo's `mise.toml`:
 
 Bootstrap a repo with `flint init` (scaffolds config). Install a
 pre-commit hook with `flint hook install`.
+This is appropriate even if the repo already has an existing `mise.toml`;
+`flint init` is not just for greenfield repos. If `init` adds tools you do not
+want, trim the generated tool list afterward.
 
 ### mise.toml setup
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Add `flint` to your repo's `mise.toml`:
 Bootstrap a repo with `flint init` (scaffolds config). Install a
 pre-commit hook with `flint hook install`.
 This is appropriate even if the repo already has an existing `mise.toml`;
-`flint init` is not just for greenfield repos. If `init` adds tools you do not
-want, trim the generated tool list afterward.
+`flint init` is not just for greenfield repos. You can choose which linters to
+enable during the prompt, or trim the generated tool list afterward if you run
+`flint init --yes`.
 
 ### mise.toml setup
 


### PR DESCRIPTION
## Summary

Clarify that `flint init` is appropriate for repositories that already use `mise`, not just greenfield setup.

## Why

The current installation section can read like there are two separate paths:

- manually add `flint` to `mise.toml`
- bootstrap with `flint init`

That can imply `flint init` is mainly for new repositories, while manual edits are the safer choice when `mise.toml` already exists.

This change makes it explicit that `flint init` is still appropriate in a repo with an existing `mise.toml`, and that users can trim the generated tool list afterward.

## Testing

- `mise run lint`
