### PR TITLE
test: guard fixture case groups

### DIFF
--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -125,9 +125,7 @@ fn test_case_groups_match_registered_checks() {
     let actual: BTreeSet<String> = std::fs::read_dir(&cases_dir)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", cases_dir.display()))
         .map(|entry| {
-            entry.unwrap_or_else(|e| {
-                panic!("failed to read entry in {}: {e}", cases_dir.display())
-            })
+            entry.unwrap_or_else(|e| panic!("failed to read entry in {}: {e}", cases_dir.display()))
         })
         .filter(|entry| entry.path().is_dir())
         .map(|entry| entry.file_name().to_string_lossy().into_owned())

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -113,6 +113,31 @@ fn version_ranges_must_not_be_mixed_with_unranged_entries() {
     }
 }
 
+#[test]
+fn test_case_groups_match_registered_checks() {
+    let cases_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/cases");
+    let mut allowed: BTreeSet<String> = builtin()
+        .into_iter()
+        .map(|check| check.name.to_string())
+        .collect();
+    allowed.insert("general".to_string());
+
+    let actual: BTreeSet<String> = std::fs::read_dir(&cases_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", cases_dir.display()))
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+
+    let unexpected: Vec<String> = actual.difference(&allowed).cloned().collect();
+
+    assert!(
+        unexpected.is_empty(),
+        "tests/cases contains top-level groups that are neither `general` nor registered checks: {}",
+        unexpected.join(", ")
+    );
+}
+
 /// Guardrail: two different fixer tools should not claim the same declared file
 /// pattern. Overlap between checks from the same underlying tool is still
 /// allowed for now (e.g. `biome` + `biome-format`, `ruff` + `ruff-format`)

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -124,7 +124,11 @@ fn test_case_groups_match_registered_checks() {
 
     let actual: BTreeSet<String> = std::fs::read_dir(&cases_dir)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", cases_dir.display()))
-        .filter_map(|entry| entry.ok())
+        .map(|entry| {
+            entry.unwrap_or_else(|e| {
+                panic!("failed to read entry in {}: {e}", cases_dir.display())
+            })
+        })
         .filter(|entry| entry.path().is_dir())
         .map(|entry| entry.file_name().to_string_lossy().into_owned())
         .collect();


### PR DESCRIPTION
## What changed
Add a registry-level test that validates the top-level `tests/cases/*` groups stay aligned with the built-in check names, with `general` as the only non-linter exception.

## Why
The fixture harness groups cases by the first path segment under `tests/cases`. If a directory name drifts from the registered check name, the fixture layout silently stops matching the actual linter identity.

This adds a guardrail so names like `ruff-format` vs `ruff-fmt` are caught by tests instead of slipping into the case tree unnoticed.

## Validation
- `cargo test test_case_groups_match_registered_checks`
- `mise run lint:fix`
- `mise run lint`
