### PR TITLE
docs: document PR title guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ type(optional scope): description
 Common types: `feat`, `fix`, `chore`, `docs`, `refactor`,
 `test`, `ci`
 
+Do not prefix PR titles with `[codex]`.
+Match the PR title type to the primary user-facing change.
+
 **Release impact:** This repository uses
 [release-please](https://github.com/googleapis/release-please).
 Only `feat:` and `fix:` trigger new releases, and breaking


### PR DESCRIPTION
## Summary
Document PR title guidance for agents working in this repository.

## What changed
- add an explicit rule not to prefix PR titles with `[codex]`
- add guidance to choose the conventional commit type based on the primary user-facing change

## Why
The repository already requires conventional PR titles for squash merges and release automation, but the agent instructions were missing these two practical rules.

## Validation
- `mise run lint:fix`