### PR TITLE
fix(init): remove stale head sha from CI snippets

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Lint
         env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: mise run lint

--- a/README.md
+++ b/README.md
@@ -110,13 +110,17 @@ run = "flint run --fix"
 
 - name: Lint
   env:
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_BASE_REF: ${{ github.base_ref }}
+    GITHUB_HEAD_REF: ${{ github.head_ref }}
+    PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
     GITHUB_TOKEN: ${{ github.token }}
-    GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   run: mise run lint
 ```
 
-`GITHUB_HEAD_SHA` tells flint which commit is the PR head when running in CI.
-`fetch-depth: 0` is required for merge-base detection.
+The GitHub environment variables let flint remap base-branch links to the PR
+branch when link checking. `fetch-depth: 0` is required for merge-base
+detection.
 
 ---
 

--- a/src/init/scaffold.rs
+++ b/src/init/scaffold.rs
@@ -55,8 +55,11 @@ jobs:
 {rust_steps}
       - name: Lint
         env:
+          GITHUB_REPOSITORY: ${{{{ github.repository }}}}
+          GITHUB_BASE_REF: ${{{{ github.base_ref }}}}
+          GITHUB_HEAD_REF: ${{{{ github.head_ref }}}}
+          PR_HEAD_REPO: ${{{{ github.event.pull_request.head.repo.full_name || github.repository }}}}
           GITHUB_TOKEN: ${{{{ github.token }}}}
-          GITHUB_HEAD_SHA: ${{{{ github.event.pull_request.head.sha }}}}
         run: mise run lint
 "#
     );

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -792,6 +792,13 @@ fn generate_lint_workflow_writes_file() {
     assert!(content.contains("fetch-depth: 0"));
     assert!(content.contains("persist-credentials: false"));
     assert!(content.contains("mise-action"));
+    assert!(content.contains("GITHUB_REPOSITORY: ${{ github.repository }}"));
+    assert!(content.contains("GITHUB_BASE_REF: ${{ github.base_ref }}"));
+    assert!(content.contains("GITHUB_HEAD_REF: ${{ github.head_ref }}"));
+    assert!(content.contains(
+        "PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+    ));
+    assert!(!content.contains("GITHUB_HEAD_SHA"));
     assert!(content.contains("github.token"));
     assert!(!content.contains("rust-cache"));
     assert!(!content.contains("rustup component"));


### PR DESCRIPTION
## Summary

Stops generated CI snippets and docs from exporting `GITHUB_HEAD_SHA`, which Rust Flint no longer reads.

The generated workflow now passes the GitHub link-remap environment Flint actually uses: `GITHUB_REPOSITORY`, `GITHUB_BASE_REF`, `GITHUB_HEAD_REF`, `PR_HEAD_REPO`, and `GITHUB_TOKEN`, while keeping `fetch-depth: 0`.

The missing-env failure/warning is intentionally deferred.

## Validation

- `cargo fmt`
- `cargo test generate_lint_workflow`
- `mise run lint:fix`
- `git diff --check`