### PR TITLE
fix: make flint-setup state-based

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,7 +137,7 @@ after the release is cut, run `flint init` again without `--flint-rev`.
 setup defaults. Routine lint runs use `flint-setup` and only fail when an
 actionable setup migration applies to the repo.
 
-To check setup drift without applying changes, run:
+To check setup migrations and `mise.toml` layout without applying changes, run:
 
 ```bash
 flint run flint-setup

--- a/src/init/config_files.rs
+++ b/src/init/config_files.rs
@@ -90,19 +90,6 @@ pub(super) fn remove_legacy_lint_files(
     Ok(removed)
 }
 
-pub(super) fn existing_legacy_lint_files(project_root: &Path, config_dir: &Path) -> Vec<String> {
-    legacy_lint_files(project_root, config_dir)
-        .into_iter()
-        .filter(|path| path.exists())
-        .map(|path| {
-            path.strip_prefix(project_root)
-                .unwrap_or(&path)
-                .display()
-                .to_string()
-        })
-        .collect()
-}
-
 fn legacy_lint_files(project_root: &Path, config_dir: &Path) -> Vec<std::path::PathBuf> {
     vec![
         project_root.join(".prettierignore"),
@@ -133,16 +120,6 @@ pub(super) fn remove_stale_markdownlint_line_length_directives(
         changed_files.push(rel.to_string());
     }
     Ok(changed_files)
-}
-
-pub(super) fn stale_markdownlint_line_length_directive_files(
-    project_root: &Path,
-) -> Result<Vec<String>> {
-    stale_transformed_files(
-        project_root,
-        &[&["*.md"]],
-        strip_stale_markdownlint_md013_directives,
-    )
 }
 
 fn tracked_files_for_patterns(project_root: &Path, patterns: &[&[&str]]) -> Result<Vec<String>> {
@@ -194,45 +171,6 @@ pub(super) fn remove_stale_editorconfig_checker_directives(
     }
     changed_files.sort();
     changed_files.dedup();
-    Ok(changed_files)
-}
-
-pub(super) fn stale_editorconfig_checker_directive_files(
-    project_root: &Path,
-    delegated_sections: &[(&[&str], EditorconfigDirectiveStyle)],
-) -> Result<Vec<String>> {
-    let mut changed_files = vec![];
-    for (patterns, directive_style) in delegated_sections {
-        changed_files.extend(stale_transformed_files(
-            project_root,
-            &[*patterns],
-            |content| strip_stale_editorconfig_checker_directives(content, *directive_style),
-        )?);
-    }
-    changed_files.sort();
-    changed_files.dedup();
-    Ok(changed_files)
-}
-
-fn stale_transformed_files<F>(
-    project_root: &Path,
-    patterns: &[&[&str]],
-    transform: F,
-) -> Result<Vec<String>>
-where
-    F: Fn(&str) -> String,
-{
-    let tracked_files = tracked_files_for_patterns(project_root, patterns)?;
-    let mut changed_files = vec![];
-    for rel in tracked_files {
-        let path = project_root.join(rel.as_str());
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        if transform(&content) != content {
-            changed_files.push(rel);
-        }
-    }
     Ok(changed_files)
 }
 

--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -9,8 +9,7 @@ pub(super) use super::mise_tools::{
     apply_changes, ensure_flint_self_pin, ensure_node_for_npm, remove_tool_keys,
 };
 pub(crate) use super::mise_tools::{
-    needs_node_for_npm, normalize_tools_section, replace_obsolete_keys,
-    tools_section_needs_normalization,
+    normalize_tools_section, replace_obsolete_keys, tools_section_needs_normalization,
 };
 pub(super) use super::v1::remove_v1_tasks;
 

--- a/src/init/migrations.rs
+++ b/src/init/migrations.rs
@@ -2,17 +2,15 @@ use anyhow::Result;
 use std::collections::HashSet;
 use std::path::Path;
 
-use crate::registry::{Check, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy, builtin};
+use crate::registry::{Check, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy};
 
 use super::config_files::{
-    existing_legacy_lint_files, remove_legacy_lint_files,
-    remove_stale_editorconfig_checker_directives, remove_stale_markdownlint_line_length_directives,
-    stale_editorconfig_checker_directive_files, stale_markdownlint_line_length_directive_files,
+    remove_legacy_lint_files, remove_stale_editorconfig_checker_directives,
+    remove_stale_markdownlint_line_length_directives,
 };
 use super::detection::parse_tool_keys;
 use super::generation;
-use super::generation::needs_node_for_npm;
-use super::{ensure_node_for_npm, install_key, remove_tool_keys};
+use super::{ensure_node_for_npm, remove_tool_keys};
 
 pub(super) struct RepoMigrationSummary {
     replaced_obsolete: Vec<(String, String)>,
@@ -21,12 +19,6 @@ pub(super) struct RepoMigrationSummary {
     legacy_files_removed: Vec<String>,
     stale_md013_comments_removed: Vec<String>,
     stale_editorconfig_checker_comments_removed: Vec<String>,
-}
-
-struct MigrationInputs {
-    tool_keys: HashSet<String>,
-    delegated_sections: Vec<(&'static [&'static str], EditorconfigDirectiveStyle)>,
-    mise_content: String,
 }
 
 impl RepoMigrationSummary {
@@ -61,59 +53,37 @@ impl RepoMigrationSummary {
     }
 }
 
-pub(crate) fn apply_setup_migrations(project_root: &Path, config_dir: &Path) -> Result<bool> {
-    let mise_path = project_root.join("mise.toml");
-    let current_content = std::fs::read_to_string(&mise_path).unwrap_or_default();
-    let current_tool_keys = parse_tool_keys(&current_content);
-    let delegated_sections = active_editorconfig_cleanup_sections(&current_tool_keys);
-    let migration_summary = apply_repo_migrations(project_root, config_dir, &delegated_sections)?;
-    Ok(!migration_summary.is_noop())
+pub(crate) fn apply_setup_migrations(project_root: &Path, _config_dir: &Path) -> Result<bool> {
+    let obsolete_keys = crate::registry::obsolete_keys();
+    let unsupported_keys = crate::registry::unsupported_keys();
+    let replaced_obsolete = generation::replace_obsolete_keys(project_root, &obsolete_keys)?;
+    let removed_unsupported = remove_tool_keys(
+        project_root,
+        &unsupported_keys
+            .iter()
+            .map(|(old_key, _)| *old_key)
+            .collect::<Vec<_>>(),
+    )?;
+    Ok(!replaced_obsolete.is_empty() || !removed_unsupported.is_empty())
 }
 
 pub(crate) fn detect_setup_migrations(
     project_root: &Path,
-    config_dir: &Path,
+    _config_dir: &Path,
     setup_migration_version: u32,
 ) -> Result<bool> {
-    let migration_summary =
-        detect_setup_migrations_after(project_root, config_dir, setup_migration_version)?;
-    Ok(!migration_summary.is_noop())
-}
+    let mise_path = project_root.join("mise.toml");
+    let current_content = std::fs::read_to_string(&mise_path).unwrap_or_default();
+    let current_tool_keys = parse_tool_keys(&current_content);
+    let obsolete_keys = crate::registry::obsolete_keys_after(setup_migration_version);
+    let unsupported_keys = crate::setup::unsupported_keys_after(setup_migration_version);
 
-pub(crate) fn detect_setup_drift(project_root: &Path, config_dir: &Path) -> Result<bool> {
-    let migration_summary = detect_repo_migrations(project_root, config_dir)?;
-    Ok(!migration_summary.is_noop())
-}
-
-pub(super) fn active_editorconfig_cleanup_sections(
-    tool_keys: &HashSet<String>,
-) -> Vec<(&'static [&'static str], EditorconfigDirectiveStyle)> {
-    let mut seen = HashSet::new();
-    let mut out = vec![];
-    for check in builtin() {
-        let Some(key) = install_key(&check) else {
-            continue;
-        };
-        if !tool_keys.contains(key) {
-            continue;
-        }
-        let EditorconfigLineLengthPolicy::DisableForPatterns {
-            patterns,
-            directive_style,
-            ..
-        } = check.editorconfig_line_length_policy
-        else {
-            continue;
-        };
-        let Some(EditorconfigDirectiveStyle::Html) = directive_style else {
-            continue;
-        };
-        let dedupe_key = patterns.join(",");
-        if seen.insert(dedupe_key) {
-            out.push((patterns, EditorconfigDirectiveStyle::Html));
-        }
-    }
-    out
+    Ok(obsolete_keys
+        .iter()
+        .any(|(old_key, _)| current_tool_keys.contains(*old_key))
+        || unsupported_keys
+            .iter()
+            .any(|(old_key, _)| current_tool_keys.contains(*old_key)))
 }
 
 pub(super) fn selected_editorconfig_line_length_sections(
@@ -175,97 +145,6 @@ pub(super) fn apply_repo_migrations(
         &obsolete_keys,
         &unsupported_keys,
     )
-}
-
-pub(crate) fn detect_repo_migrations(
-    project_root: &Path,
-    config_dir: &Path,
-) -> Result<RepoMigrationSummary> {
-    let inputs = migration_inputs(project_root)?;
-    let obsolete_keys = crate::registry::obsolete_keys();
-    let unsupported_keys = crate::registry::unsupported_keys();
-    detect_repo_migrations_with_keys(
-        project_root,
-        config_dir,
-        &inputs.delegated_sections,
-        &obsolete_keys,
-        &unsupported_keys,
-        &inputs.tool_keys,
-        &inputs.mise_content,
-    )
-}
-
-pub(crate) fn detect_setup_migrations_after(
-    project_root: &Path,
-    config_dir: &Path,
-    setup_migration_version: u32,
-) -> Result<RepoMigrationSummary> {
-    let inputs = migration_inputs(project_root)?;
-    let obsolete_keys = crate::registry::obsolete_keys_after(setup_migration_version);
-    let unsupported_keys = crate::setup::unsupported_keys_after(setup_migration_version);
-    detect_repo_migrations_with_keys(
-        project_root,
-        config_dir,
-        &inputs.delegated_sections,
-        &obsolete_keys,
-        &unsupported_keys,
-        &inputs.tool_keys,
-        &inputs.mise_content,
-    )
-}
-
-fn migration_inputs(project_root: &Path) -> Result<MigrationInputs> {
-    let mise_path = project_root.join("mise.toml");
-    let current_content = std::fs::read_to_string(&mise_path).unwrap_or_default();
-    let current_tool_keys = parse_tool_keys(&current_content);
-    let delegated_sections = active_editorconfig_cleanup_sections(&current_tool_keys);
-    Ok(MigrationInputs {
-        tool_keys: current_tool_keys,
-        delegated_sections,
-        mise_content: current_content,
-    })
-}
-
-fn detect_repo_migrations_with_keys(
-    project_root: &Path,
-    config_dir: &Path,
-    delegated_sections: &[(&'static [&'static str], EditorconfigDirectiveStyle)],
-    obsolete_keys: &[(&'static str, &'static str)],
-    unsupported_keys: &[(&'static str, &'static str)],
-    tool_keys: &HashSet<String>,
-    mise_content: &str,
-) -> Result<RepoMigrationSummary> {
-    let replaced_obsolete = obsolete_keys
-        .iter()
-        .filter(|(old_key, _)| tool_keys.contains(*old_key))
-        .map(|(old_key, new_key)| ((*old_key).to_string(), (*new_key).to_string()))
-        .collect();
-    let removed_unsupported = unsupported_keys
-        .iter()
-        .filter(|(old_key, _)| tool_keys.contains(*old_key))
-        .map(|(old_key, _)| (*old_key).to_string())
-        .collect();
-    let node_added = needs_node_for_npm(mise_content);
-    let legacy_files_removed = existing_legacy_lint_files(project_root, config_dir);
-    let stale_md013_comments_removed = if delegated_patterns_include(delegated_sections, "*.md") {
-        stale_markdownlint_line_length_directive_files(project_root)?
-    } else {
-        vec![]
-    };
-    let stale_editorconfig_checker_comments_removed = if delegated_sections.is_empty() {
-        vec![]
-    } else {
-        stale_editorconfig_checker_directive_files(project_root, delegated_sections)?
-    };
-
-    Ok(RepoMigrationSummary {
-        replaced_obsolete,
-        removed_unsupported,
-        node_added,
-        legacy_files_removed,
-        stale_md013_comments_removed,
-        stale_editorconfig_checker_comments_removed,
-    })
 }
 
 fn apply_repo_migrations_with_keys(

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -32,7 +32,7 @@ use migrations::{
     apply_repo_migrations, selected_editorconfig_cleanup_sections,
     selected_editorconfig_line_length_sections,
 };
-pub(crate) use migrations::{apply_setup_migrations, detect_setup_drift, detect_setup_migrations};
+pub(crate) use migrations::{apply_setup_migrations, detect_setup_migrations};
 use scaffold::{apply_env_and_tasks, generate_lint_workflow, maybe_install_hook};
 use ui::{interactive_select_linters, select_categories_arrow};
 

--- a/src/linters/flint_setup.rs
+++ b/src/linters/flint_setup.rs
@@ -66,7 +66,6 @@ pub async fn run(
     let flint_toml = config_dir.join("flint.toml");
     let mut errors = vec![];
     let mut versioned_migrations_pending = false;
-    let mut setup_drift_reported = false;
 
     if flint_toml.exists() && setup_migration_version > crate::setup::LATEST_SUPPORTED_SETUP_VERSION
     {
@@ -82,19 +81,10 @@ pub async fn run(
         ) {
             Ok(true) => {
                 versioned_migrations_pending = true;
-                setup_drift_reported = true;
                 errors.push(format!(
                     "Flint setup migrations after version {setup_migration_version} apply to this repo."
                 ));
             }
-            Ok(false) => {}
-            Err(e) => return LinterOutput::err(format!("flint: flint-setup: {e}\n")),
-        }
-    }
-
-    if !setup_drift_reported {
-        match crate::init::detect_setup_drift(project_root, config_dir) {
-            Ok(true) => errors.push("Flint setup drift applies to this repo.".to_string()),
             Ok(false) => {}
             Err(e) => return LinterOutput::err(format!("flint: flint-setup: {e}\n")),
         }
@@ -242,16 +232,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_setup_migration_version_still_reports_actionable_drift() {
+    async fn current_setup_migration_version_ignores_broad_cleanup_drift() {
         let tmp = tempfile::TempDir::new().unwrap();
         std::fs::write(
             tmp.path().join("mise.toml"),
-            "[tools]\n\"npm:renovate\" = \"latest\"\n",
+            "[tools]\n\n# Linters\nrumdl = \"0.1.78\"\n",
         )
         .unwrap();
         std::fs::write(
             tmp.path().join("flint.toml"),
             "[settings]\nsetup_migration_version = 2\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("README.md"),
+            "<!-- markdownlint-disable MD013 -->\n# Title\n",
         )
         .unwrap();
 
@@ -263,12 +258,33 @@ mod tests {
         )
         .await;
 
-        assert!(!out.ok);
-        assert!(
-            String::from_utf8(out.stderr)
-                .unwrap()
-                .contains("Flint setup drift applies to this repo")
-        );
+        assert!(out.ok, "{}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    #[tokio::test]
+    async fn fix_mode_does_not_apply_broad_repo_cleanup() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let readme = "<!-- markdownlint-disable MD013 -->\n# Title\n";
+        std::fs::write(
+            tmp.path().join("mise.toml"),
+            "[tools]\nrumdl = \"0.1.78\"\nnode = \"24.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("README.md"), readme).unwrap();
+
+        let out = run(
+            true,
+            tmp.path(),
+            tmp.path(),
+            crate::setup::LATEST_SUPPORTED_SETUP_VERSION,
+        )
+        .await;
+        let content = std::fs::read_to_string(tmp.path().join("mise.toml")).unwrap();
+        let readme_after = std::fs::read_to_string(tmp.path().join("README.md")).unwrap();
+
+        assert!(out.ok, "{}", String::from_utf8_lossy(&out.stderr));
+        assert!(content.contains("# Linters"));
+        assert_eq!(readme_after, readme);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make `flint-setup` state-based instead of version-counter-based.

`flint-setup` no longer persists or advances `settings.setup_migration_version`. Routine check mode now stays focused on current actionable setup state from `mise.toml`: obsolete tool-key migrations, unsupported legacy lint tools, missing `node` for `npm:` backends, and canonical `[tools]` ordering.

`flint-setup --fix` still does the heavy lifting for active setup migrations, but only when the current tool state actually activates that migration. In practice this keeps routine checks cheap and unsurprising while still letting a Flint/tool update branch apply the full migration directly.

For the markdownlint-era stack, that means fix mode removes the old tool entries and applies the repo cleanup only when those legacy tools are still present in `mise.toml`. Ambient stale comments in unrelated repos no longer surface as generic setup drift.

This also removes now-vestigial setup migration plumbing:

- drop `settings.setup_migration_version` from generated and parsed `flint.toml`
- remove fix-time writeback of setup migration state
- make old tool-key replacements unconditional when their legacy keys are present

## Validation

- `cargo test flint_setup -- --nocapture`
- `cargo test init::tests -- --nocapture`
- `cargo test registry -- --nocapture`
- `FLINT_CASES=general/flint-setup cargo test cases -- --nocapture`
- `mise run lint:fix`
- `mise run lint`
