### PR TITLE
fix(init): enable yamllint indentation rule

### DIFF
--- a/.github/config/.yamllint.yml
+++ b/.github/config/.yamllint.yml
@@ -4,5 +4,4 @@ rules:
   document-start: disable
   line-length:
     max: 130
-  indentation:
-    spaces: 2
+  indentation: enable

--- a/src/init/config_files.rs
+++ b/src/init/config_files.rs
@@ -779,8 +779,7 @@ pub(super) fn generate_yamllint_config(config_dir: &Path, line_length: u16) -> R
         "  document-start: disable",
         "  line-length:",
         &format!("    max: {line_length}"),
-        "  indentation:",
-        "    spaces: 2",
+        "  indentation: enable",
         "",
     ]
     .join("\n");

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -588,12 +588,10 @@ fn generate_yamllint_config_writes_file() {
     let written = generate_yamllint_config(&config_dir, DEFAULT_LINE_LENGTH).unwrap();
     assert!(written);
     let content = std::fs::read_to_string(config_dir.join(".yamllint.yml")).unwrap();
-    assert!(content.contains("extends: relaxed"));
-    assert!(content.contains("document-start: disable"));
-    assert!(content.contains("line-length:"));
-    assert!(content.contains("max: 120"));
-    assert!(content.contains("indentation:"));
-    assert!(content.contains("spaces: 2"));
+    assert_eq!(
+        content,
+        "extends: relaxed\n\nrules:\n  document-start: disable\n  line-length:\n    max: 120\n  indentation: enable\n"
+    );
 }
 
 #[test]

--- a/tests/cases/general/init-rust/test.toml
+++ b/tests/cases/general/init-rust/test.toml
@@ -50,8 +50,7 @@ rules:
   document-start: disable
   line-length:
     max: 120
-  indentation:
-    spaces: 2
+  indentation: enable
 '''
 ".github/config/flint.toml" = '''
 [settings]

--- a/tests/cases/ryl/clean/files/.github/config/.yamllint.yml
+++ b/tests/cases/ryl/clean/files/.github/config/.yamllint.yml
@@ -4,5 +4,4 @@ rules:
   document-start: disable
   line-length:
     max: 100
-  indentation:
-    spaces: 2
+  indentation: enable

--- a/tests/cases/ryl/failure/files/.github/config/.yamllint.yml
+++ b/tests/cases/ryl/failure/files/.github/config/.yamllint.yml
@@ -4,5 +4,4 @@ rules:
   document-start: disable
   line-length:
     max: 100
-  indentation:
-    spaces: 2
+  indentation: enable


### PR DESCRIPTION
## Summary

Converges generated `.github/config/.yamllint.yml` on `indentation: enable` instead of the legacy nested `spaces: 2` shape.

The generator test now asserts the exact generated config so this does not drift back to ad hoc variants.

## Validation

- `cargo test generate_yamllint_config_writes_file`
- `FLINT_CASES=general/init-rust cargo test cases`
- `FLINT_CASES=ryl mise exec -- cargo test cases`
- `mise run lint:fix`
- `mise run lint`
- `mise exec -- cargo test --bins -- --skip registry::tests::all_registry_binaries_found`

Note: full `cargo test --bins` is blocked in this environment by missing `dotnet-format`.