### PR TITLE
fix: match mise linter presets by dep name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,7 +62,7 @@
   ],
   packageRules: [
     {
-      matchPackageNames: [
+      matchDepNames: [
         "actionlint",
         "aqua:owenlamont/ryl",
         "biome",

--- a/default.json
+++ b/default.json
@@ -36,7 +36,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "actionlint",
         "aqua:owenlamont/ryl",
         "biome",

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -397,7 +397,7 @@ fn default_renovate_preset_covers_all_linter_tools_weekly() {
         .find(|rule| rule["groupName"].as_str() == Some("linters"))
         .expect("default.json must define a packageRules entry with groupName 'linters'");
 
-    let actual = package_names(linters_rule);
+    let actual = dep_names(linters_rule);
     let expected: Vec<&str> = builtin()
         .into_iter()
         .filter(|check| check.uses_binary())
@@ -413,8 +413,8 @@ fn default_renovate_preset_covers_all_linter_tools_weekly() {
     );
     assert_eq!(
         actual,
-        sorted_package_names(linters_rule),
-        "default.json weekly linters rule matchPackageNames must be sorted"
+        sorted_dep_names(linters_rule),
+        "default.json weekly linters rule matchDepNames must be sorted"
     );
 
     assert_eq!(
@@ -461,14 +461,14 @@ fn repo_renovate_config_stays_aligned_with_shared_preset_contract() {
             "package rule {group_name:?} schedule in .github/renovate.json5 drifted from default.json"
         );
         assert_eq!(
-            package_names(default_rule),
-            package_names(repo_rule),
-            "package rule {group_name:?} matchPackageNames in .github/renovate.json5 drifted from default.json"
+            rule_names(default_rule),
+            rule_names(repo_rule),
+            "package rule {group_name:?} package matcher in .github/renovate.json5 drifted from default.json"
         );
         assert_eq!(
-            package_names(repo_rule),
-            sorted_package_names(repo_rule),
-            "package rule {group_name:?} matchPackageNames in .github/renovate.json5 must be sorted"
+            rule_names(repo_rule),
+            sorted_rule_names(repo_rule),
+            "package rule {group_name:?} package matcher in .github/renovate.json5 must be sorted"
         );
     }
 
@@ -553,8 +553,35 @@ fn package_names(rule: &serde_json::Value) -> Vec<&str> {
         .collect()
 }
 
-fn sorted_package_names(rule: &serde_json::Value) -> Vec<&str> {
-    let mut names = package_names(rule);
+fn dep_names(rule: &serde_json::Value) -> Vec<&str> {
+    rule["matchDepNames"]
+        .as_array()
+        .expect("package rule must declare matchDepNames")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("package rule matchDepNames entries must be strings")
+        })
+        .collect()
+}
+
+fn sorted_dep_names(rule: &serde_json::Value) -> Vec<&str> {
+    let mut names = dep_names(rule);
+    names.sort_unstable();
+    names
+}
+
+fn rule_names(rule: &serde_json::Value) -> Vec<&str> {
+    if rule.get("matchDepNames").is_some() {
+        dep_names(rule)
+    } else {
+        package_names(rule)
+    }
+}
+
+fn sorted_rule_names(rule: &serde_json::Value) -> Vec<&str> {
+    let mut names = rule_names(rule);
     names.sort_unstable();
     names
 }

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -461,6 +461,11 @@ fn repo_renovate_config_stays_aligned_with_shared_preset_contract() {
             "package rule {group_name:?} schedule in .github/renovate.json5 drifted from default.json"
         );
         assert_eq!(
+            rule_name_field(default_rule),
+            rule_name_field(repo_rule),
+            "package rule {group_name:?} matcher field in .github/renovate.json5 drifted from default.json"
+        );
+        assert_eq!(
             rule_names(default_rule),
             rule_names(repo_rule),
             "package rule {group_name:?} package matcher in .github/renovate.json5 drifted from default.json"
@@ -570,6 +575,14 @@ fn sorted_dep_names(rule: &serde_json::Value) -> Vec<&str> {
     let mut names = dep_names(rule);
     names.sort_unstable();
     names
+}
+
+fn rule_name_field(rule: &serde_json::Value) -> &'static str {
+    if rule.get("matchDepNames").is_some() {
+        "matchDepNames"
+    } else {
+        "matchPackageNames"
+    }
 }
 
 fn rule_names(rule: &serde_json::Value) -> Vec<&str> {

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -578,18 +578,26 @@ fn sorted_dep_names(rule: &serde_json::Value) -> Vec<&str> {
 }
 
 fn rule_name_field(rule: &serde_json::Value) -> &'static str {
-    if rule.get("matchDepNames").is_some() {
-        "matchDepNames"
-    } else {
-        "matchPackageNames"
+    match (
+        rule.get("matchDepNames").is_some(),
+        rule.get("matchPackageNames").is_some(),
+    ) {
+        (true, false) => "matchDepNames",
+        (false, true) => "matchPackageNames",
+        (true, true) => {
+            panic!("package rule must not declare both matchDepNames and matchPackageNames")
+        }
+        (false, false) => {
+            panic!("package rule must declare matchDepNames or matchPackageNames")
+        }
     }
 }
 
 fn rule_names(rule: &serde_json::Value) -> Vec<&str> {
-    if rule.get("matchDepNames").is_some() {
-        dep_names(rule)
-    } else {
-        package_names(rule)
+    match rule_name_field(rule) {
+        "matchDepNames" => dep_names(rule),
+        "matchPackageNames" => package_names(rule),
+        _ => unreachable!("unexpected rule_name_field result"),
     }
 }
 


### PR DESCRIPTION
Blocked by https://github.com/grafana/flint/pull/253


## Summary
- switch the weekly `linters` Renovate rule to match `mise` short-name tools by `depName`
- keep the shared preset and repo-local Renovate config aligned on the same matcher
- tighten the registry drift tests around the weekly linter preset contract

## Why
`mise` short-name tools like `lychee`, `ruff`, and `rumdl` can extract with a `depName` that matches the key in `mise.toml` while `packageName` resolves to the upstream repo. Matching the weekly linter preset by `packageName` can therefore miss valid linter updates.

## Validation
- `cargo test default_renovate_preset_covers_all_linter_tools_weekly`
- `cargo test repo_renovate_config_stays_aligned_with_shared_preset_contract`
