### PR TITLE
chore(renovate): simplify quickstart and batch weekly linter updates

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -19,6 +19,13 @@
       "mise"
     ]
   },
+  "README.md": {
+    "regex": [
+      "koalaman/shellcheck",
+      "mvdan/sh",
+      "rhysd/actionlint"
+    ]
+  },
   "mise.toml": {
     "mise": [
       "actionlint",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,36 @@
     },
     {
       customType: "regex",
+      description: "Update shellcheck version in README quickstart example",
+      managerFilePatterns: ["/^README\\.md$/"],
+      matchStrings: [
+        "# Add whichever linters apply to your repo:\\n[\\s\\S]*?\"github:koalaman/shellcheck\"\\s*=\\s*\"(?<currentValue>[^\"]+)\"[\\s\\S]*?\\n```",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "koalaman/shellcheck",
+    },
+    {
+      customType: "regex",
+      description: "Update shfmt version in README quickstart example",
+      managerFilePatterns: ["/^README\\.md$/"],
+      matchStrings: [
+        "# Add whichever linters apply to your repo:\\n[\\s\\S]*?shfmt\\s*=\\s*\"(?<currentValue>[^\"]+)\"[\\s\\S]*?\\n```",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "mvdan/sh",
+    },
+    {
+      customType: "regex",
+      description: "Update actionlint version in README quickstart example",
+      managerFilePatterns: ["/^README\\.md$/"],
+      matchStrings: [
+        "# Add whichever linters apply to your repo:\\n[\\s\\S]*?actionlint\\s*=\\s*\"(?<currentValue>[^\"]+)\"[\\s\\S]*?\\n```",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "rhysd/actionlint",
+    },
+    {
+      customType: "regex",
       description: "Update mise version in GitHub Actions workflows",
       managerFilePatterns: ["/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/", "/(^|/)action\\.ya?ml$/"],
       datasourceTemplate: "github-release-attachments",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -112,8 +112,10 @@
         "taplo",
       ],
       groupName: "linters",
+      commitMessageTopic: "flint-managed linter updates",
       description: "Only update flint-managed linters once a week",
       schedule: ["before 4am on Monday"],
+      separateMajorMinor: false,
     },
     {
       matchPackageNames: ["jdx/mise"],

--- a/README.md
+++ b/README.md
@@ -74,15 +74,6 @@ Add the linting tools your project needs alongside the `flint` binary itself:
 "github:koalaman/shellcheck" = "0.11.0"
 shfmt                   = "v3.13.1"
 actionlint              = "1.7.10"
-rumdl                   = "0.1.78"
-ruff                    = "0.15.12"
-"aqua:owenlamont/ryl"   = "0.6.0"
-taplo                   = "0.10.0"
-biome                   = "2.4.12"
-rust                    = "1.95.0"    # activates cargo-fmt + cargo-clippy
-go                      = "1.26.2"    # activates gofmt
-lychee                  = "0.22.0"    # activates links check
-"npm:renovate"          = "43.141.6"  # activates renovate-deps check
 ```
 
 Then wire up lint tasks:

--- a/default.json
+++ b/default.json
@@ -56,8 +56,10 @@
         "taplo"
       ],
       "groupName": "linters",
+      "commitMessageTopic": "flint-managed linter updates",
       "description": "Only update flint-managed linters once a week",
-      "schedule": ["before 4am on Monday"]
+      "schedule": ["before 4am on Monday"],
+      "separateMajorMinor": false
     },
     {
       "matchPackageNames": ["jdx/mise"],

--- a/src/bin/sync-readme-snippets.rs
+++ b/src/bin/sync-readme-snippets.rs
@@ -75,28 +75,11 @@ fn render_quickstart_tools(table: &toml::Table) -> Result<String> {
 \"github:koalaman/shellcheck\" = \"{shellcheck}\"\n\
 shfmt                   = \"{shfmt}\"\n\
 actionlint              = \"{actionlint}\"\n\
-rumdl                   = \"{rumdl}\"\n\
-ruff                    = \"{ruff}\"\n\
-\"aqua:owenlamont/ryl\"   = \"{ryl}\"\n\
-taplo                   = \"{taplo}\"\n\
-biome                   = \"{biome}\"\n\
-rust                    = \"{rust}\"    # activates cargo-fmt + cargo-clippy\n\
-go                      = \"{go}\"    # activates gofmt\n\
-lychee                  = \"{lychee}\"    # activates links check\n\
-\"npm:renovate\"          = \"{renovate}\"  # activates renovate-deps check",
+",
         flint = env!("CARGO_PKG_VERSION"),
         shellcheck = versions["github:koalaman/shellcheck"],
         shfmt = versions["shfmt"],
         actionlint = versions["actionlint"],
-        rumdl = versions["rumdl"],
-        ruff = versions["ruff"],
-        ryl = versions["aqua:owenlamont/ryl"],
-        taplo = versions["taplo"],
-        biome = versions["biome"],
-        rust = versions["rust"],
-        go = versions["go"],
-        lychee = versions["lychee"],
-        renovate = versions["npm:renovate"],
     ))
 }
 

--- a/src/readme_snippets.rs
+++ b/src/readme_snippets.rs
@@ -1,17 +1,4 @@
 pub const INSTALL_MARKER: &str = "Add `flint` to your repo's `mise.toml`:";
 pub const QUICKSTART_MARKER: &str =
     "Add the linting tools your project needs alongside the `flint` binary itself:";
-pub const QUICKSTART_KEYS: &[&str] = &[
-    "github:koalaman/shellcheck",
-    "shfmt",
-    "actionlint",
-    "rumdl",
-    "ruff",
-    "aqua:owenlamont/ryl",
-    "taplo",
-    "biome",
-    "rust",
-    "go",
-    "lychee",
-    "npm:renovate",
-];
+pub const QUICKSTART_KEYS: &[&str] = &["github:koalaman/shellcheck", "shfmt", "actionlint"];

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -472,15 +472,19 @@ fn repo_renovate_config_stays_aligned_with_shared_preset_contract() {
         );
     }
 
-    let description = "Update mise version in GitHub Actions workflows";
-    let default_manager = custom_manager_by_description(&default_parsed, description)
-        .unwrap_or_else(|| panic!("default.json missing custom manager {description:?}"));
-    let repo_manager = custom_manager_by_description(&repo_parsed, description)
-        .unwrap_or_else(|| panic!(".github/renovate.json5 missing custom manager {description:?}"));
-    assert_eq!(
-        default_manager, repo_manager,
-        "custom manager {description:?} in .github/renovate.json5 drifted from default.json"
-    );
+    {
+        let description = "Update mise version in GitHub Actions workflows";
+        let default_manager = custom_manager_by_description(&default_parsed, description)
+            .unwrap_or_else(|| panic!("default.json missing custom manager {description:?}"));
+        let repo_manager =
+            custom_manager_by_description(&repo_parsed, description).unwrap_or_else(|| {
+                panic!(".github/renovate.json5 missing custom manager {description:?}")
+            });
+        assert_eq!(
+            default_manager, repo_manager,
+            "custom manager {description:?} in .github/renovate.json5 drifted from default.json"
+        );
+    }
 }
 
 #[test]
@@ -645,7 +649,6 @@ fn readme_quickstart_tools_snippets_stay_current() {
             env!("CARGO_PKG_VERSION").to_string(),
         )))
         .collect::<std::collections::BTreeMap<_, _>>();
-
     let actual = toml_tool_versions_from_table(
         quickstart_tools,
         &[
@@ -653,15 +656,6 @@ fn readme_quickstart_tools_snippets_stay_current() {
             "github:koalaman/shellcheck",
             "shfmt",
             "actionlint",
-            "rumdl",
-            "ruff",
-            "aqua:owenlamont/ryl",
-            "taplo",
-            "biome",
-            "rust",
-            "go",
-            "lychee",
-            "npm:renovate",
         ],
     );
 

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -424,6 +424,16 @@ fn default_renovate_preset_covers_all_linter_tools_weekly() {
         )]),
         "linters package rule must remain on the weekly Monday schedule"
     );
+    assert_eq!(
+        linters_rule["commitMessageTopic"].as_str(),
+        Some("flint-managed linter updates"),
+        "linters package rule must keep the grouped PR title readable"
+    );
+    assert_eq!(
+        linters_rule["separateMajorMinor"].as_bool(),
+        Some(false),
+        "linters package rule must keep major and non-major updates in one Monday PR"
+    );
     assert!(
         !actual.contains(&"node"),
         "node is a runtime prerequisite, not a linter, and must not be in the weekly linters rule"
@@ -459,6 +469,14 @@ fn repo_renovate_config_stays_aligned_with_shared_preset_contract() {
         assert_eq!(
             default_rule["schedule"], repo_rule["schedule"],
             "package rule {group_name:?} schedule in .github/renovate.json5 drifted from default.json"
+        );
+        assert_eq!(
+            default_rule["commitMessageTopic"], repo_rule["commitMessageTopic"],
+            "package rule {group_name:?} commitMessageTopic in .github/renovate.json5 drifted from default.json"
+        );
+        assert_eq!(
+            default_rule["separateMajorMinor"], repo_rule["separateMajorMinor"],
+            "package rule {group_name:?} separateMajorMinor in .github/renovate.json5 drifted from default.json"
         );
         assert_eq!(
             package_names(default_rule),


### PR DESCRIPTION
Blocked by https://github.com/grafana/flint/pull/253

## Summary

- shrink the README quickstart `[tools]` example to three representative linters
- manage those three README example versions with repo-local Renovate regex managers
- keep the shared `default.json` free of repo-specific README rules
- update the Renovate drift test so only shared managers are compared against `default.json`
- keep flint-managed linter updates in a single weekly Monday Renovate PR with a clearer generated title

## Why

The previous approach made README quickstart version drift break Renovate PRs, even though the README example is repository-specific. This change keeps the example small, keeps its version bumps automatic, and avoids pushing repo-local behavior into the shared preset.

The follow-up Renovate change also keeps linter bumps batched into one Monday PR, including majors, so the repo gets one coordinated linter-update PR instead of split grouped PRs with generic titles.

## Validation

- `renovate-config-validator --no-global .github/renovate.json5`
- `cargo test repo_renovate_config_stays_aligned_with_shared_preset_contract -- --nocapture`
- `cargo test readme_quickstart_tools_snippets_stay_current -- --nocapture`
- `cargo test default_renovate_preset_covers_all_linter_tools_weekly`
- `cargo test repo_renovate_config_stays_aligned_with_shared_preset_contract`
- `mise run lint:fix`
