### PR TITLE
fix(init): normalize node runtime before linters

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -367,6 +367,10 @@ Add and stage your source files before running init so the detection is accurate
 
     let meta_changed =
         apply_env_and_tasks(&mise_path, &config_dir_rel, has_slow, &v1.removed_tasks)?;
+    let node_added = ensure_node_for_npm(project_root)?;
+    if node_added {
+        println!("  added node (LTS) — required by npm: backend tools");
+    }
     let tools_normalized = normalize_tools_section(&mise_path)?;
 
     let base_branch = detect_base_branch(project_root);
@@ -411,6 +415,7 @@ Add and stage your source files before running init so the detection is accurate
         && v1.removed_tasks.is_empty()
         && !v1.removed_renovate_env
         && !meta_changed
+        && !node_added
         && !tools_normalized
         && !toml_generated
         && !workflow_generated

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -3,7 +3,8 @@ use crate::registry::CheckTypeDef;
 use config_files::generate_flint_toml;
 use detection::entry_components_differ;
 use generation::{
-    apply_changes, get_existing_config_dir, has_slow_selected, normalize_tools_section,
+    apply_changes, ensure_node_for_npm, get_existing_config_dir, has_slow_selected,
+    normalize_tools_section,
 };
 use scaffold::{apply_env_and_tasks, generate_lint_workflow};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -217,6 +218,34 @@ protoc = "34.1"
         "only explicitly managed linter keys belong below the header:\n{result}"
     );
     assert_eq!(result.matches("# Linters").count(), 1, "single header");
+}
+
+#[test]
+fn node_added_for_npm_tools_is_normalized_above_linters_header() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("mise.toml");
+    let content = "[tools]\n";
+    std::fs::write(&path, content).unwrap();
+
+    apply_changes(
+        &path,
+        content,
+        &[("npm:renovate".to_string(), None)],
+        &[],
+        &[],
+    )
+    .unwrap();
+    assert!(ensure_node_for_npm(dir.path()).unwrap());
+    normalize_tools_section(&path).unwrap();
+
+    let result = std::fs::read_to_string(&path).unwrap();
+    let node_pos = result.find("node =").expect("node present");
+    let header_pos = result.find("# Linters").expect("header present");
+    let renovate_pos = result.find("\"npm:renovate\"").expect("renovate present");
+    assert!(
+        node_pos < header_pos && header_pos < renovate_pos,
+        "node runtime must stay above the linter block:\n{result}"
+    );
 }
 
 #[test]

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -3,11 +3,15 @@ use crate::registry::CheckTypeDef;
 use config_files::generate_flint_toml;
 use detection::entry_components_differ;
 use generation::{
-    apply_changes, ensure_node_for_npm, get_existing_config_dir, has_slow_selected,
-    normalize_tools_section,
+    apply_changes, get_existing_config_dir, has_slow_selected, normalize_tools_section,
 };
 use scaffold::{apply_env_and_tasks, generate_lint_workflow};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicUsize, Ordering},
+};
+
+static PATH_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
 static CHECK_TYPE_INIT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
@@ -18,6 +22,52 @@ fn counting_check_type_init(_: &dyn InitHookContext) -> anyhow::Result<bool> {
 
 static COUNTING_CHECK_TYPE: CheckTypeDef =
     CheckTypeDef::with_init_hook("shared-hook", counting_check_type_init);
+
+fn init_git_repo(path: &Path) {
+    let status = std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git init failed");
+}
+
+fn with_fake_mise<R>(body: impl FnOnce() -> R) -> R {
+    let _path_guard = PATH_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let temp = tempfile::TempDir::new().unwrap();
+    let fake_mise = temp.path().join("mise");
+    std::fs::write(&fake_mise, "#!/bin/sh\nexit 1\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&fake_mise).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_mise, perms).unwrap();
+    }
+
+    let original_path = std::env::var_os("PATH");
+    let mut paths = vec![temp.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &original_path.clone().unwrap_or_default(),
+    ));
+    let joined = std::env::join_paths(paths).unwrap();
+
+    // PATH updates are process-global; serialize tests that shadow `mise`.
+    unsafe {
+        std::env::set_var("PATH", &joined);
+    }
+
+    let result = body();
+
+    unsafe {
+        match original_path {
+            Some(path) => std::env::set_var("PATH", path),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    result
+}
 
 #[test]
 fn detect_obsolete_keys_finds_known_stale_key() {
@@ -221,22 +271,25 @@ protoc = "34.1"
 }
 
 #[test]
-fn node_added_for_npm_tools_is_normalized_above_linters_header() {
+fn init_run_normalizes_node_added_for_existing_npm_tool() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("mise.toml");
-    let content = "[tools]\n";
-    std::fs::write(&path, content).unwrap();
-
-    apply_changes(
+    init_git_repo(dir.path());
+    std::fs::write(
         &path,
-        content,
-        &[("npm:renovate".to_string(), None)],
-        &[],
-        &[],
+        "[tools]\n\n# Linters\n\"npm:renovate\" = \"43.0.0\"\n",
     )
     .unwrap();
-    assert!(ensure_node_for_npm(dir.path()).unwrap());
-    normalize_tools_section(&path).unwrap();
+
+    with_fake_mise(|| {
+        run(
+            dir.path(),
+            Some(Profile::Comprehensive),
+            true,
+            Some("rev:test"),
+        )
+        .unwrap();
+    });
 
     let result = std::fs::read_to_string(&path).unwrap();
     let node_pos = result.find("node =").expect("node present");
@@ -244,7 +297,7 @@ fn node_added_for_npm_tools_is_normalized_above_linters_header() {
     let renovate_pos = result.find("\"npm:renovate\"").expect("renovate present");
     assert!(
         node_pos < header_pos && header_pos < renovate_pos,
-        "node runtime must stay above the linter block:\n{result}"
+        "init::run must keep node above the linter block:\n{result}"
     );
 }
 


### PR DESCRIPTION
## What changed
This updates `flint init` so the `node` runtime is added before `[tools]` normalization when an `npm:` backend tool such as `npm:renovate` is selected.

## Why
`init` already ensured `node` indirectly through the later migration pass, but that happened after `[tools]` normalization. The result was a valid `mise.toml` with `node` appended under the `# Linters` block instead of being grouped with runtime tools above it.

## Impact
Generated `mise.toml` files now keep `node` in the runtime section while still adding it automatically for `npm:` tools.

## Root cause
The init flow normalized `[tools]` before calling the helper that inserts `node`, so the final write order was wrong even though the dependency was present.

## Validation
- `cargo test init::tests::node_added_for_npm_tools_is_normalized_above_linters_header -- --exact`
- `cargo test init::tests::normalize_tools_section_moves_node_above_linters_header -- --exact`
- `cargo test init::tests::compute_desired_tools_comprehensive_includes_slow -- --exact`
- `mise run lint:fix`
