### PR TITLE
ci: pass git-token and forge to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create release metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mise run release:create -- --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github
+        run: mise run release:create --git-token "$GITHUB_TOKEN"
 
   release-pr:
     # Runs on every push to main. Keeps an open PR that bumps Cargo.toml version
@@ -60,4 +60,6 @@ jobs:
           version: v2026.5.0
           sha256: 7db5db7a36d28203eb8329140d98fb26b41f5efea32d762f69a1e4b369e1e1a8
       - name: Update release PR
-        run: mise run release:pr -- --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mise run release:pr --git-token "$GITHUB_TOKEN"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create release metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mise run release:create
+        run: mise run release:create -- --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github
 
   release-pr:
     # Runs on every push to main. Keeps an open PR that bumps Cargo.toml version
@@ -60,6 +60,4 @@ jobs:
           version: v2026.5.0
           sha256: 7db5db7a36d28203eb8329140d98fb26b41f5efea32d762f69a1e4b369e1e1a8
       - name: Update release PR
-        run: mise run release:pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mise run release:pr -- --git-token "${{ secrets.GITHUB_TOKEN }}" --forge github

--- a/.mise/tasks/release/create
+++ b/.mise/tasks/release/create
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
 #MISE description="Create git tags and GitHub releases when a release PR was merged"
-#USAGE arg "[args]" var=#true help="Additional arguments passed to release-plz release"
+#USAGE flag "--git-token <token>" help="GitHub token used by release-plz and gh"
 
 set -euo pipefail
 
-if [ -z "${GITHUB_TOKEN:-}" ]; then
-	echo "GITHUB_TOKEN environment variable is not set. Exiting."
+if [ -z "${usage_git_token:-}" ]; then
+	echo "--git-token is required" >&2
 	exit 1
 fi
 
 tmp_json="$(mktemp)"
 trap 'rm -f "${tmp_json}"' EXIT
 
-release_args=()
-if [ -n "${usage_args:-}" ]; then
-	# Mise provides variadic args as a shell-escaped string.
-	eval "release_args=(${usage_args})"
-fi
-
-release-plz release -o json "${release_args[@]}" >"${tmp_json}"
+release-plz release --git-token "${usage_git_token}" --forge github -o json >"${tmp_json}"
 
 jq -e '.releases and (.releases | type == "array")' "${tmp_json}" >/dev/null
 
@@ -27,9 +21,7 @@ if ! jq -e '.releases | length > 0' "${tmp_json}" >/dev/null; then
 	exit 0
 fi
 
-if [ -z "${GH_TOKEN:-}" ]; then
-	export GH_TOKEN="${GITHUB_TOKEN}"
-fi
+export GH_TOKEN="${usage_git_token}"
 
 tag="$(jq -r '.releases[0].tag' "${tmp_json}")"
 

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#MISE description="Open or update the release PR"
+#MISE depends=["release:update"]
+#USAGE arg "[args]" var=#true help="Additional arguments passed to release-plz release-pr"
+
+set -euo pipefail
+
+pr_args=()
+if [ -n "${usage_args:-}" ]; then
+	# Mise provides variadic args as a shell-escaped string.
+	eval "pr_args=(${usage_args})"
+fi
+
+release-plz release-pr --allow-dirty "${pr_args[@]}"

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Open or update the release PR"
 #MISE depends=["release:update"]
-#USAGE arg "[args]" var=#true help="Additional arguments passed to release-plz release-pr"
+#USAGE flag "--git-token <token>" help="GitHub token used by release-plz"
 
 set -euo pipefail
 
-pr_args=()
-if [ -n "${usage_args:-}" ]; then
-	# Mise provides variadic args as a shell-escaped string.
-	eval "pr_args=(${usage_args})"
+if [ -z "${usage_git_token:-}" ]; then
+	echo "--git-token is required" >&2
+	exit 1
 fi
 
-release-plz release-pr --allow-dirty "${pr_args[@]}"
+release-plz release-pr --allow-dirty --git-token "${usage_git_token}" --forge github

--- a/mise.toml
+++ b/mise.toml
@@ -39,11 +39,6 @@ run = "cargo run -q --bin flint -- run"
 description = "Auto-fix lint issues"
 run = "cargo run -q --bin flint -- run --fix"
 
-[tasks."release:pr"]
-description = "Open or update the release PR"
-depends = ["release:update"]
-run = "release-plz release-pr --allow-dirty"
-
 [tasks.build]
 description = "Build the project"
 run = "cargo build"


### PR DESCRIPTION
## Summary

- Pass `--git-token` and `--forge github` to `release-plz release` and `release-plz release-pr` from the workflow as usage args.
- Extract `release:pr` from inline `mise.toml` to `.mise/tasks/release/pr` so it can forward variadic args the same way `release:create` already does.

## Why

release-plz 0.3.x requires explicit `--git-token` and `--forge` for both `release` and `release-pr`. Without them, both fail with:

```text
ERROR git release not configured. Did you specify git-token and forge?
```

Every release-plz workflow run since [#234](https://github.com/grafana/flint/pull/234) has been failing for that reason, leaving release PR [#242](https://github.com/grafana/flint/pull/242) stuck on its 2026-04-28 snapshot. After this merges, the next push to `main` will refresh #242 with all merged commits since.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, next push to `main` refreshes #242 with all merged commits + correct version bump (note: `#270` was `refactor!` so the bump should be a major increment per release-plz semantics)