### PR TITLE
fix(ci): drop double release-plz update from release:pr

### DIFF
--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Open or update the release PR"
-#MISE depends=["release:update"]
 #USAGE flag "--git-token <token>" help="GitHub token used by release-plz"
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Drop `#MISE depends=["release:update"]` from `.mise/tasks/release/pr`.

## Why

`release-plz release-pr` already runs `update` internally. Chaining `release:update` as a `depends` made every CI run bump and regenerate the changelog **twice**.

Visible symptom: release PR [#242](https://github.com/grafana/flint/pull/242) currently shows `v0.23.0` with every PR since project start in the changelog. The first successful release-plz run after [#274](https://github.com/grafana/flint/pull/274) merged actually computed the right thing — the run log shows:

```
INFO determining next version for flint 0.21.0
INFO flint: next version is 0.22.0
* flint: 0.21.0 -> 0.22.0
```

…and then the chained second `update` (via `release-plz release-pr`'s internal call) bumped 0.22.0 → 0.23.0 on top of an already-bumped tree, regenerating the whole CHANGELOG.

`release:update` stays available for local manual previews.

## After merge

The next push to `main` should refresh #242 to `v0.22.0` with only commits since `v0.21.0`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, release PR #242 retitles to `chore: release v0.22.0` and changelog scope shrinks to commits since `v0.21.0`