### PR TITLE
fix(ci): sync README on release branch after release-plz release-pr

### DIFF
--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -9,4 +9,35 @@ if [ -z "${usage_git_token:-}" ]; then
 	exit 1
 fi
 
-release-plz release-pr --allow-dirty --git-token "${usage_git_token}" --forge github
+release-plz release-pr --git-token "${usage_git_token}" --forge github
+
+# release-plz pushed (or updated) a release branch with bumped Cargo.toml +
+# CHANGELOG. Sync README snippets on that branch to the new version and
+# push as an additional commit so the release PR stays consistent.
+git fetch origin '+refs/heads/release-plz-*:refs/remotes/origin/release-plz-*'
+
+release_branch="$(git for-each-ref \
+	--sort=-committerdate \
+	--format='%(refname:lstrip=3)' \
+	'refs/remotes/origin/release-plz-*' | head -n 1)"
+
+if [ -z "${release_branch}" ]; then
+	echo "No release-plz branch found; nothing to sync."
+	exit 0
+fi
+
+git checkout -B "${release_branch}" "origin/${release_branch}"
+
+mise run release:docs-sync
+
+if git diff --quiet; then
+	echo "README already in sync."
+	exit 0
+fi
+
+git -c user.name='github-actions[bot]' \
+	-c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+	commit -am "chore: sync README snippets"
+
+git push "https://x-access-token:${usage_git_token}@github.com/${GITHUB_REPOSITORY:-grafana/flint}.git" \
+	"HEAD:${release_branch}"

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -39,5 +39,6 @@ git -c user.name='github-actions[bot]' \
 	-c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
 	commit -am "chore: sync README snippets"
 
-git push "https://x-access-token:${usage_git_token}@github.com/${GITHUB_REPOSITORY:-grafana/flint}.git" \
-	"HEAD:${release_branch}"
+repo="${GITHUB_REPOSITORY:-grafana/flint}"
+remote_url="https://x-access-token:${usage_git_token}@github.com/${repo}.git"
+git push "${remote_url}" "HEAD:${release_branch}"

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -9,6 +9,11 @@ if [ -z "${usage_git_token:-}" ]; then
 	exit 1
 fi
 
+if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+	echo "GITHUB_REPOSITORY is required (this task is CI-only)" >&2
+	exit 1
+fi
+
 release-plz release-pr --git-token "${usage_git_token}" --forge github
 
 # Sync README pin to the new version on the release branch as a follow-up
@@ -27,7 +32,7 @@ fi
 
 git checkout -B "${release_branch}" "origin/${release_branch}"
 
-mise run release:docs-sync
+cargo run -q --bin sync-readme-snippets
 
 if git diff --quiet; then
 	echo "README already in sync."
@@ -38,6 +43,5 @@ git -c user.name='github-actions[bot]' \
 	-c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
 	commit -am "chore: sync README snippets"
 
-repo="${GITHUB_REPOSITORY:-grafana/flint}"
-remote_url="https://x-access-token:${usage_git_token}@github.com/${repo}.git"
+remote_url="https://x-access-token:${usage_git_token}@github.com/${GITHUB_REPOSITORY}.git"
 git push "${remote_url}" "HEAD:${release_branch}"

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -39,8 +39,16 @@ if git diff --quiet; then
 	exit 0
 fi
 
-git -c user.name='github-actions[bot]' \
-	-c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+# Derive commit identity from the token so it matches the GitHub actor
+# that owns the push (e.g. github-actions[bot] for GITHUB_TOKEN, a real
+# user for a PAT).
+gh_user="$(GH_TOKEN="${usage_git_token}" gh api user)"
+git_login="$(jq -r .login <<<"${gh_user}")"
+git_id="$(jq -r .id <<<"${gh_user}")"
+git_email="${git_id}+${git_login}@users.noreply.github.com"
+
+git -c user.name="${git_login}" \
+	-c user.email="${git_email}" \
 	commit -am "chore: sync README snippets"
 
 remote_url="https://x-access-token:${usage_git_token}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.mise/tasks/release/pr
+++ b/.mise/tasks/release/pr
@@ -11,9 +11,8 @@ fi
 
 release-plz release-pr --git-token "${usage_git_token}" --forge github
 
-# release-plz pushed (or updated) a release branch with bumped Cargo.toml +
-# CHANGELOG. Sync README snippets on that branch to the new version and
-# push as an additional commit so the release PR stays consistent.
+# Sync README pin to the new version on the release branch as a follow-up
+# commit; release-plz won't include this change itself.
 git fetch origin '+refs/heads/release-plz-*:refs/remotes/origin/release-plz-*'
 
 release_branch="$(git for-each-ref \


### PR DESCRIPTION
## Summary

After `release-plz release-pr` pushes the release branch with the bumped `Cargo.toml` + `CHANGELOG`, check it out and run `release:docs-sync` there, then push any `README`/`Cargo.lock` updates as an additional commit.

## Why

Without this the README pin stays at the previous version and the `readme_quickstart_tools_snippets_stay_current` test fails on the release PR — that's what blocked [#242](https://github.com/grafana/flint/pull/242) after the v0.22.0 bump.

This was the second commit of [#276](https://github.com/grafana/flint/pull/276) that didn't make it through the squash merge.

## Caveats

- Each release-plz run force-pushes the release branch and wipes the docs-sync commit. Docs-sync re-runs in the same workflow run and re-creates it, so the PR stays consistent — but CI may briefly see two pushes.
- Uses `https://x-access-token:$TOKEN@github.com/...` for the push because `actions/checkout` runs with `persist-credentials: false`.

## Test plan

- [ ] CI green on this PR
- [ ] On next push to main, release PR refreshes with both bumped Cargo.toml/CHANGELOG and synced README in the same workflow run