### PR TITLE
fix(renovate-deps): surface real renovate failure in error output

### DIFF
--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -577,12 +577,56 @@ async fn run_renovate(
         anyhow::bail!(
             "renovate exited with status {}: {}",
             out.status.code().unwrap_or(-1),
-            snippet.lines().take(20).collect::<Vec<_>>().join("\n")
+            extract_failure_snippet(&snippet)
         );
     }
 
     Ok(combined)
 }
+/// Extracts the most informative slice of a Renovate log for an error message.
+///
+/// Renovate emits one JSON log object per line with a numeric `level` field
+/// (bunyan: 30=info, 40=warn, 50=error, 60=fatal). Startup is dominated by
+/// debug/info lines, so taking the head of the log usually hides the actual
+/// failure. Prefer level >= 40 entries; fall back to the tail of the log.
+fn extract_failure_snippet(log: &str) -> String {
+    const MAX_LINES: usize = 20;
+
+    let high_level: Vec<String> = log
+        .lines()
+        .filter_map(|line| {
+            let value: serde_json::Value = serde_json::from_str(line).ok()?;
+            let level = value.get("level")?.as_u64()?;
+            if level < 40 {
+                return None;
+            }
+            let msg = value.get("msg").and_then(|v| v.as_str()).unwrap_or("");
+            let err = value
+                .get("err")
+                .and_then(|v| v.get("message"))
+                .and_then(|v| v.as_str());
+            Some(match err {
+                Some(e) => format!("level={level} {msg}: {e}"),
+                None => format!("level={level} {msg}"),
+            })
+        })
+        .collect();
+
+    fn tail<I: IntoIterator>(items: I, n: usize) -> Vec<I::Item> {
+        let mut v: Vec<I::Item> = items.into_iter().collect();
+        if v.len() > n {
+            v.drain(..v.len() - n);
+        }
+        v
+    }
+
+    if high_level.is_empty() {
+        tail(log.lines(), MAX_LINES).join("\n")
+    } else {
+        tail(high_level.iter().map(String::as_str), MAX_LINES).join("\n")
+    }
+}
+
 fn resolve_renovate_config_path(project_root: &Path) -> anyhow::Result<PathBuf> {
     RENOVATE_CONFIG_PATTERNS
         .iter()

--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -600,15 +600,24 @@ fn extract_failure_snippet(log: &str) -> String {
             if level < 40 {
                 return None;
             }
-            let msg = value.get("msg").and_then(|v| v.as_str()).unwrap_or("");
+            let msg = value
+                .get("msg")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty());
             let err = value
                 .get("err")
                 .and_then(|v| v.get("message"))
                 .and_then(|v| v.as_str());
-            Some(match err {
-                Some(e) => format!("level={level} {msg}: {e}"),
-                None => format!("level={level} {msg}"),
-            })
+            let mut out = format!("level={level}");
+            if let Some(m) = msg {
+                out.push(' ');
+                out.push_str(m);
+            }
+            if let Some(e) = err {
+                out.push_str(if msg.is_some() { ": " } else { " " });
+                out.push_str(e);
+            }
+            Some(out)
         })
         .collect();
 

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -944,6 +944,16 @@ fn extract_failure_snippet_prefers_error_lines() {
 }
 
 #[test]
+fn extract_failure_snippet_handles_missing_msg() {
+    let log = "\
+{\"level\":50,\"err\":{\"message\":\"boom\"}}\n\
+{\"level\":60,\"msg\":\"\",\"err\":{\"message\":\"fatal\"}}\n\
+{\"level\":40,\"msg\":\"warn only\"}\n";
+    let snippet = extract_failure_snippet(log);
+    assert_eq!(snippet, "level=50 boom\nlevel=60 fatal\nlevel=40 warn only");
+}
+
+#[test]
 fn extract_failure_snippet_falls_back_to_tail() {
     let mut log = String::new();
     for i in 0..30 {

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -931,3 +931,27 @@ fn relevant_when_snapshot_is_unparsable() {
         dir.path()
     ));
 }
+
+#[test]
+fn extract_failure_snippet_prefers_error_lines() {
+    let log = "\
+{\"level\":20,\"msg\":\"Parsing configs\"}\n\
+{\"level\":30,\"msg\":\"Renovate started\"}\n\
+{\"level\":50,\"msg\":\"Failed\",\"err\":{\"message\":\"boom\"}}\n\
+{\"level\":20,\"msg\":\"trailing debug\"}\n";
+    let snippet = extract_failure_snippet(log);
+    assert_eq!(snippet, "level=50 Failed: boom");
+}
+
+#[test]
+fn extract_failure_snippet_falls_back_to_tail() {
+    let mut log = String::new();
+    for i in 0..30 {
+        log.push_str(&format!("{{\"level\":20,\"msg\":\"line {i}\"}}\n"));
+    }
+    let snippet = extract_failure_snippet(&log);
+    let lines: Vec<&str> = snippet.lines().collect();
+    assert_eq!(lines.len(), 20);
+    assert!(lines.last().unwrap().contains("line 29"));
+    assert!(lines.first().unwrap().contains("line 10"));
+}


### PR DESCRIPTION
## Summary
- The renovate-deps linter previously truncated the renovate log to the **first** 20 lines on failure, which on a typical run are debug/info startup messages — the actual fatal error never made it into the bail message.
- Prefer JSON log entries with `level >= 40` (warn/error/fatal), including `err.message` when present.
- Fall back to the **last** 20 lines when no high-level entries exist.

## Motivation
Reported by Jay: `flint run --fix` against `prometheus/client_java` failed with `renovate exited with status 1` followed by 20 lines of `level":20` debug output, with no indication of what actually went wrong.

## Test plan
- [x] `cargo test --bin flint extract_failure` — both new unit tests pass
- [x] `cargo clippy --all-targets --no-deps`
- [ ] Re-run renovate against a known-failing repo and confirm the surfaced snippet contains the fatal/error line