### PR TITLE
fix(init): improve interactive init feedback

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -1,6 +1,5 @@
 [settings]
 exclude = ["CHANGELOG.md", "super-linter-versions/**", "tests/cases/**"]
-setup_migration_version = 2
 
 [checks.renovate-deps]
 exclude_managers = ["github-actions", "github-runners", "cargo"]

--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -48,18 +48,20 @@ pub(super) fn get_existing_config_dir(content: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-pub(super) fn select_config_dir(input: &str) -> Option<&'static str> {
-    const CHOICES: &[&str] = &[".github/config", ".github", ".", "other…"];
+const CONFIG_DIR_CHOICES: &[&str] = &[".github/config", ".github", ".", "other…"];
+
+pub(super) fn select_config_dir(input: &str) -> &'static str {
     let input = input.trim();
     let idx: usize = if input.is_empty() {
         0
     } else {
         input.parse::<usize>().unwrap_or(1).saturating_sub(1)
     };
-    CHOICES
+    CONFIG_DIR_CHOICES
         .get(idx)
         .copied()
-        .or_else(|| CHOICES.first().copied())
+        .or_else(|| CONFIG_DIR_CHOICES.first().copied())
+        .unwrap_or(".github/config")
 }
 
 /// Asks where `flint.toml` should live. Skips the prompt when `--yes` or when
@@ -74,9 +76,8 @@ pub(super) fn prompt_config_dir(existing: Option<&str>, yes: bool) -> Result<Str
         return Ok(".github/config".to_string());
     }
 
-    const CHOICES: &[&str] = &[".github/config", ".github", ".", "other…"];
     println!("Where should flint.toml live?\n");
-    for (i, choice) in CHOICES.iter().enumerate() {
+    for (i, choice) in CONFIG_DIR_CHOICES.iter().enumerate() {
         println!("  {}) {}", i + 1, choice);
     }
     print!("\nChoice [1]: ");
@@ -84,7 +85,7 @@ pub(super) fn prompt_config_dir(existing: Option<&str>, yes: bool) -> Result<Str
 
     let mut input = String::new();
     io::stdin().lock().read_line(&mut input)?;
-    let selected = select_config_dir(&input).unwrap_or(".github/config");
+    let selected = select_config_dir(&input);
 
     if selected == "other…" {
         print!("Config dir path: ");

--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -48,7 +48,9 @@ pub(super) fn get_existing_config_dir(content: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-const CONFIG_DIR_CHOICES: &[&str] = &[".github/config", ".github", ".", "other…"];
+const DEFAULT_CONFIG_DIR: &str = ".github/config";
+const OTHER_CONFIG_DIR_CHOICE: &str = "other...";
+const CONFIG_DIR_CHOICES: &[&str] = &[DEFAULT_CONFIG_DIR, ".github", ".", OTHER_CONFIG_DIR_CHOICE];
 
 pub(super) fn select_config_dir(input: &str) -> &'static str {
     let input = input.trim();
@@ -61,7 +63,7 @@ pub(super) fn select_config_dir(input: &str) -> &'static str {
         .get(idx)
         .copied()
         .or_else(|| CONFIG_DIR_CHOICES.first().copied())
-        .unwrap_or(".github/config")
+        .unwrap_or(DEFAULT_CONFIG_DIR)
 }
 
 /// Asks where `flint.toml` should live. Skips the prompt when `--yes` or when
@@ -73,7 +75,7 @@ pub(super) fn prompt_config_dir(existing: Option<&str>, yes: bool) -> Result<Str
         return Ok(dir.to_string());
     }
     if yes {
-        return Ok(".github/config".to_string());
+        return Ok(DEFAULT_CONFIG_DIR.to_string());
     }
 
     println!("Where should flint.toml live?\n");
@@ -87,7 +89,7 @@ pub(super) fn prompt_config_dir(existing: Option<&str>, yes: bool) -> Result<Str
     io::stdin().lock().read_line(&mut input)?;
     let selected = select_config_dir(&input);
 
-    if selected == "other…" {
+    if selected == OTHER_CONFIG_DIR_CHOICE {
         print!("Config dir path: ");
         io::stdout().flush()?;
         let mut path = String::new();

--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -48,6 +48,20 @@ pub(super) fn get_existing_config_dir(content: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+pub(super) fn select_config_dir(input: &str) -> Option<&'static str> {
+    const CHOICES: &[&str] = &[".github/config", ".github", ".", "other…"];
+    let input = input.trim();
+    let idx: usize = if input.is_empty() {
+        0
+    } else {
+        input.parse::<usize>().unwrap_or(1).saturating_sub(1)
+    };
+    CHOICES
+        .get(idx)
+        .copied()
+        .or_else(|| CHOICES.first().copied())
+}
+
 /// Asks where `flint.toml` should live. Skips the prompt when `--yes` or when
 /// `FLINT_CONFIG_DIR` is already set in the current mise.toml.
 ///
@@ -70,21 +84,18 @@ pub(super) fn prompt_config_dir(existing: Option<&str>, yes: bool) -> Result<Str
 
     let mut input = String::new();
     io::stdin().lock().read_line(&mut input)?;
-    let input = input.trim();
+    let selected = select_config_dir(&input).unwrap_or(".github/config");
 
-    let idx: usize = if input.is_empty() {
-        0
-    } else {
-        input.parse::<usize>().unwrap_or(1).saturating_sub(1)
-    };
-
-    if idx == CHOICES.len() - 1 {
+    if selected == "other…" {
         print!("Config dir path: ");
         io::stdout().flush()?;
         let mut path = String::new();
         io::stdin().lock().read_line(&mut path)?;
-        Ok(path.trim().to_string())
+        let path = path.trim().to_string();
+        println!("Using config dir: {path}");
+        Ok(path)
     } else {
-        Ok(CHOICES[idx.min(CHOICES.len() - 2)].to_string())
+        println!("Using config dir: {selected}");
+        Ok(selected.to_string())
     }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -358,8 +358,8 @@ Add and stage your source files before running init so the detection is accurate
 
     let tools_changed =
         !final_add.is_empty() || !final_remove.is_empty() || !final_upgrade.is_empty();
-    interactive_note(yes, "\nApplying mise/tooling changes...");
     if tools_changed {
+        interactive_note(yes, "\nApplying mise/tooling changes...");
         apply_changes(
             &mise_path,
             &current_content,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -38,6 +38,12 @@ use ui::{interactive_select_linters, select_categories_arrow};
 
 const DEFAULT_LINE_LENGTH: u16 = 120;
 
+fn interactive_note(yes: bool, message: &str) {
+    if !yes {
+        println!("{message}");
+    }
+}
+
 /// Linter profile — shorthand for `--profile` CLI flag; maps to a category set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Profile {
@@ -342,10 +348,17 @@ Add and stage your source files before running init so the detection is accurate
 
     // Prompt for the flint config dir (skipped if already set in mise.toml or --yes).
     let existing_config_dir = get_existing_config_dir(&current_content);
+    if existing_config_dir.is_some() {
+        interactive_note(
+            yes,
+            "Using existing FLINT_CONFIG_DIR from mise.toml; skipping config-dir prompt.",
+        );
+    }
     let config_dir_rel = prompt_config_dir(existing_config_dir.as_deref(), yes)?;
 
     let tools_changed =
         !final_add.is_empty() || !final_remove.is_empty() || !final_upgrade.is_empty();
+    interactive_note(yes, "\nApplying mise/tooling changes...");
     if tools_changed {
         apply_changes(
             &mise_path,
@@ -375,6 +388,7 @@ Add and stage your source files before running init so the detection is accurate
     }
     let tools_normalized = normalize_tools_section(&mise_path)?;
 
+    interactive_note(yes, "\nScaffolding flint config and workflow...");
     let base_branch = detect_base_branch(project_root);
     let config_dir_path = project_root.join(&config_dir_rel);
     let toml_generated = generate_flint_toml(&config_dir_path, &base_branch)?;
@@ -431,6 +445,7 @@ Add and stage your source files before running init so the detection is accurate
         return Ok(());
     }
 
+    interactive_note(yes, "\nFinishing setup...");
     maybe_install_hook(project_root, yes)?;
 
     println!("Done. Run `mise install` to install the new tools.");

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -4,6 +4,7 @@ use config_files::generate_flint_toml;
 use detection::entry_components_differ;
 use generation::{
     apply_changes, get_existing_config_dir, has_slow_selected, normalize_tools_section,
+    select_config_dir,
 };
 use scaffold::{apply_env_and_tasks, ensure_agent_linting_guidance, generate_lint_workflow};
 use std::sync::{
@@ -446,6 +447,26 @@ fn get_existing_config_dir_reads_env_section() {
 fn get_existing_config_dir_absent() {
     let content = "[tools]\nrust = \"latest\"\n";
     assert_eq!(get_existing_config_dir(content), None);
+}
+
+#[test]
+fn select_config_dir_defaults_to_github_config_on_enter() {
+    assert_eq!(select_config_dir(""), Some(".github/config"));
+    assert_eq!(select_config_dir("\n"), Some(".github/config"));
+}
+
+#[test]
+fn select_config_dir_maps_numbered_choices() {
+    assert_eq!(select_config_dir("1"), Some(".github/config"));
+    assert_eq!(select_config_dir("2"), Some(".github"));
+    assert_eq!(select_config_dir("3"), Some("."));
+    assert_eq!(select_config_dir("4"), Some("other…"));
+}
+
+#[test]
+fn select_config_dir_falls_back_to_default_for_invalid_input() {
+    assert_eq!(select_config_dir("abc"), Some(".github/config"));
+    assert_eq!(select_config_dir("99"), Some(".github/config"));
 }
 
 #[test]

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -451,22 +451,22 @@ fn get_existing_config_dir_absent() {
 
 #[test]
 fn select_config_dir_defaults_to_github_config_on_enter() {
-    assert_eq!(select_config_dir(""), Some(".github/config"));
-    assert_eq!(select_config_dir("\n"), Some(".github/config"));
+    assert_eq!(select_config_dir(""), ".github/config");
+    assert_eq!(select_config_dir("\n"), ".github/config");
 }
 
 #[test]
 fn select_config_dir_maps_numbered_choices() {
-    assert_eq!(select_config_dir("1"), Some(".github/config"));
-    assert_eq!(select_config_dir("2"), Some(".github"));
-    assert_eq!(select_config_dir("3"), Some("."));
-    assert_eq!(select_config_dir("4"), Some("other…"));
+    assert_eq!(select_config_dir("1"), ".github/config");
+    assert_eq!(select_config_dir("2"), ".github");
+    assert_eq!(select_config_dir("3"), ".");
+    assert_eq!(select_config_dir("4"), "other…");
 }
 
 #[test]
 fn select_config_dir_falls_back_to_default_for_invalid_input() {
-    assert_eq!(select_config_dir("abc"), Some(".github/config"));
-    assert_eq!(select_config_dir("99"), Some(".github/config"));
+    assert_eq!(select_config_dir("abc"), ".github/config");
+    assert_eq!(select_config_dir("99"), ".github/config");
 }
 
 #[test]

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -460,7 +460,7 @@ fn select_config_dir_maps_numbered_choices() {
     assert_eq!(select_config_dir("1"), ".github/config");
     assert_eq!(select_config_dir("2"), ".github");
     assert_eq!(select_config_dir("3"), ".");
-    assert_eq!(select_config_dir("4"), "other…");
+    assert_eq!(select_config_dir("4"), "other...");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make `flint init` confirm the selected config dir in interactive mode
- add lightweight progress notes during interactive init so Enter presses do not feel ignored
- keep `--yes` non-interactive mode quiet while adding tests for config-dir selection behavior

## Why
Interactive `flint init` could appear to stall after accepting the default config-dir choice. Pressing Enter again could then accidentally accept the later hook prompt, because there was no visible confirmation that the first prompt had already advanced.

## User impact
Users running interactive `flint init` now get clearer feedback about what was selected and what step is running next. Non-interactive `--yes` output stays quiet.

## Validation
- `cargo test`
- `mise run lint:fix`
- `mise run lint`