### PR TITLE
docs: simplify positioning copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flint"
 version = "0.22.2"
 edition = "2024"
-description = "mise-native lint orchestrator"
+description = "Fast, simple linting that doesn't slow down your AI coding"
 license = "Apache-2.0"
 repository = "https://github.com/grafana/flint"
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 <!-- markdownlint-enable MD033 MD041 -->
 
-Linter runner built for speed, consistency, and low setup friction:
+Flint is a fast, simple lint runner that doesn't slow down your AI coding.
 
 - **Fast** — native execution (no Docker), parallel, diff-aware
   (changed files only), opt-in (undeclared tools don't run), small binary


### PR DESCRIPTION
## What changed
- simplify the README intro line to lead with Flint as fast and simple
- update the repository description metadata in `Cargo.toml` to match that positioning

## Why it changed
The previous copy leaned too much on implementation detail for the first impression. This version keeps the message focused on the two core values: fast and simple, while preserving the AI-coding punch line.

## Impact
- clearer, less technical positioning in the README hero copy
- repository metadata better matches the intended public description

## Validation
- `mise run lint:fix`