### PR TITLE
fix: skip generated git-tracked files during linting

### DIFF
--- a/.github/agents/knowledge/design.md
+++ b/.github/agents/knowledge/design.md
@@ -38,10 +38,12 @@
    template model. Their implementations live in
    `src/linters/`.
 
-7. **Built-in file exclusions**: `src/files.rs` has a
-   `BUILTIN_EXCLUDES` slice of paths that are always removed
-   from the file list before any linter sees it. Currently
-   contains `.github/renovate-tracked-deps.json` (a
-   generated file that should never be linted by `rumdl`,
-   ec, etc.). Add entries here — not in user-facing `exclude`
-   docs — when a file is managed by flint itself.
+7. **Built-in + shared generated exclusions**: `src/files.rs`
+   removes two classes of files before generic linting:
+   flint-managed committed paths in `BUILTIN_EXCLUDES`, and
+   any tracked file marked `linguist-generated` in
+   `.gitattributes`. Prefer that route for user repos so
+   GitHub and other tools can reuse the same generated-file
+   metadata. Reserve
+   `BUILTIN_EXCLUDES` for files managed by flint itself such
+   as `.github/renovate-tracked-deps.json`.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ mise run lint:fix
 Flint fixes what it can, tells you when everything is already good, and tells
 you what still needs review.
 
-**By default, Flint checks only changed files.** Use `--full` to check every
-matching file.
+**By default, Flint checks only changed tracked files.** Use `--full` to check
+every matching tracked file. Flint also skips files marked
+`linguist-generated` in `.gitattributes`; prefer that over Flint-only excludes
+so GitHub and other tools can reuse the same metadata.
 
 For more commands and flags, see the [CLI reference](docs/cli.md).
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ For more commands and flags, see the [CLI reference](docs/cli.md).
 Flint activates checks from your repo's `mise.toml`: if a Flint-managed tool is
 declared there, that check is active; if it is not declared, Flint skips it.
 
+### What's the best way to exclude files from linting?
+
+Flint never lints untracked files. This question is about files that are
+tracked in git.
+
+There are three main options:
+
+1. Mark generated files in `.gitattributes` with `linguist-generated`
+2. Add repo-wide Flint excludes in `flint.toml` via `settings.exclude`
+3. Use a tool-specific exclude in the linter's own config, when that tool
+   needs behavior Flint should not manage globally
+
+**Recommended:** use `.gitattributes` for generated files whenever possible.
+That lets Flint, GitHub, and other tools share the same generated-file
+metadata. See the [CLI reference](docs/cli.md#changed-file-and-baseline-runs)
+for details.
+
 ## Versioning
 
 This project uses [Semantic Versioning](https://semver.org/).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Read the [background and principles](docs/why.md) and
 
 > [!TIP]
 > **Legacy v1** (bash task scripts): see [README-V1.md](README-V1.md).
+>
+> **Compatibility note:** the Flint Renovate preset still includes deprecated
+> custom managers for downstream repos that rely on legacy v1 patterns such as
+> SHA-pinned `raw.githubusercontent.com/.../<sha>/... # vX.Y.Z` task URLs and
+> `_VERSION` variables in `mise.toml`. This PR removes Flint's own v1 assets,
+> but the preset compatibility path remains for consumers during migration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ Read the [background and principles](docs/why.md) and
 
 > [!TIP]
 > **Legacy v1** (bash task scripts): see [README-V1.md](README-V1.md).
->
-> **Compatibility note:** the Flint Renovate preset still includes deprecated
-> custom managers for downstream repos that rely on legacy v1 patterns such as
-> SHA-pinned `raw.githubusercontent.com/.../<sha>/... # vX.Y.Z` task URLs and
-> `_VERSION` variables in `mise.toml`. This PR removes Flint's own v1 assets,
-> but the preset compatibility path remains for consumers during migration.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,10 +43,14 @@ All `flint run` flags above have env var equivalents.
 
 ## Changed-file and baseline runs
 
-By default, local `flint run` checks linters triggered by changes relative to
-the merge base. In CI, `flint run` activates the full linter set while still
-keeping diff-aware scoping where each linter supports it. Use `--full` to
-check every matching file explicitly.
+By default, local `flint run` checks tracked files triggered by changes
+relative to the merge base. In CI, `flint run` activates the full linter set
+while still keeping diff-aware scoping where each linter supports it. Use
+`--full` to check every matching tracked file explicitly.
+
+Flint skips files marked `linguist-generated` in `.gitattributes`. Prefer that
+over Flint-only `settings.exclude` entries when the file is generated, because
+GitHub and other tools can reuse the same metadata.
 
 Some changed-file runs intentionally expand one or more affected checks to all
 matching files. This establishes a baseline when lint coverage changes, while

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use std::collections::{BTreeSet, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::config::Config;
 use crate::linters::renovate_deps::COMMITTED_PATHS;
@@ -40,7 +42,7 @@ pub fn changed(
         let to = to_ref.unwrap_or("HEAD");
         let names = collect_changed_names(project_root, base, to)?;
         (
-            filter_names(project_root, &exclude, names.clone()),
+            filter_names(project_root, &exclude, names.clone())?,
             names.into_iter().collect(),
         )
     } else {
@@ -136,13 +138,13 @@ fn all_files(project_root: &Path, exclude: &GlobSet) -> Result<FileList> {
         anyhow::bail!("git ls-files failed ({}): {}", out.status, stderr.trim());
     }
 
-    let names: std::collections::BTreeSet<String> = String::from_utf8_lossy(&out.stdout)
+    let names: BTreeSet<String> = String::from_utf8_lossy(&out.stdout)
         .lines()
         .map(str::to_string)
         .collect();
 
     Ok(FileList {
-        files: filter_names(project_root, exclude, names),
+        files: filter_names(project_root, exclude, names)?,
         changed_paths: vec![],
         merge_base: None,
         full: true,
@@ -176,15 +178,64 @@ fn git_diff_names(project_root: &Path, extra_args: &[&str]) -> Result<Vec<String
 fn filter_names(
     project_root: &Path,
     exclude: &GlobSet,
-    names: std::collections::BTreeSet<String>,
-) -> Vec<PathBuf> {
-    names
+    names: BTreeSet<String>,
+) -> Result<Vec<PathBuf>> {
+    let generated = generated_paths(project_root, &names)?;
+
+    Ok(names
         .into_iter()
         .filter(|name| !BUILTIN_EXCLUDES.contains(&name.as_str()))
+        .filter(|name| !generated.contains(name))
         .filter(|name| !exclude.is_match(name))
         .map(|name| project_root.join(name))
         .filter(|path| path.exists())
-        .collect()
+        .collect())
+}
+
+fn generated_paths(project_root: &Path, names: &BTreeSet<String>) -> Result<HashSet<String>> {
+    if names.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut child = Command::new("git")
+        .args(["check-attr", "--stdin", "-z", "linguist-generated"])
+        .current_dir(project_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("git check-attr")?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("git check-attr stdin was not piped")?;
+        for name in names {
+            stdin
+                .write_all(name.as_bytes())
+                .and_then(|_| stdin.write_all(b"\0"))
+                .context("writing git check-attr stdin")?;
+        }
+    }
+
+    let out = child.wait_with_output().context("git check-attr")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
+    }
+
+    let mut generated = HashSet::new();
+    let fields: Vec<&[u8]> = out.stdout.split(|byte| *byte == 0).collect();
+    for chunk in fields.chunks_exact(3) {
+        let path = String::from_utf8_lossy(chunk[0]);
+        let info = String::from_utf8_lossy(chunk[2]);
+        if info == "set" {
+            generated.insert(path.into_owned());
+        }
+    }
+
+    Ok(generated)
 }
 
 pub fn match_files<'a>(
@@ -245,13 +296,60 @@ mod tests {
     #[test]
     fn filter_names_skips_deleted_worktree_paths() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let out = Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git init failed");
         std::fs::write(tmp.path().join("present.md"), "ok\n").unwrap();
         let names = ["missing.md".to_string(), "present.md".to_string()]
             .into_iter()
             .collect();
 
-        let files = filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names);
+        let files =
+            filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
 
         assert_eq!(files, vec![tmp.path().join("present.md")]);
+    }
+
+    #[test]
+    fn filter_names_skips_generated_paths_from_gitattributes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        for args in [
+            ["init", "-b", "main"].as_slice(),
+            ["config", "user.email", "test@test.com"].as_slice(),
+            ["config", "user.name", "Test"].as_slice(),
+        ] {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(tmp.path())
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {:?} failed", args);
+        }
+
+        std::fs::write(
+            tmp.path().join(".gitattributes"),
+            "generated.sh linguist-generated\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("generated.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(tmp.path().join("custom.txt"), "not excluded\n").unwrap();
+        std::fs::write(tmp.path().join("tracked.sh"), "#!/bin/sh\n").unwrap();
+
+        let names = ["custom.txt", "generated.sh", "tracked.sh"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+
+        let files =
+            filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
+
+        assert_eq!(
+            files,
+            vec![tmp.path().join("custom.txt"), tmp.path().join("tracked.sh")]
+        );
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,9 +1,8 @@
 use anyhow::{Context, Result};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use std::collections::{BTreeSet, HashSet};
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use crate::config::Config;
 use crate::linters::renovate_deps::COMMITTED_PATHS;
@@ -197,41 +196,34 @@ fn generated_paths(project_root: &Path, names: &BTreeSet<String>) -> Result<Hash
         return Ok(HashSet::new());
     }
 
-    let mut child = Command::new("git")
-        .args(["check-attr", "--stdin", "-z", "linguist-generated"])
-        .current_dir(project_root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("git check-attr")?;
-
-    {
-        let mut stdin = child
-            .stdin
-            .take()
-            .context("git check-attr stdin was not piped")?;
-        for name in names {
-            stdin
-                .write_all(name.as_bytes())
-                .and_then(|_| stdin.write_all(b"\0"))
-                .context("writing git check-attr stdin")?;
-        }
-    }
-
-    let out = child.wait_with_output().context("git check-attr")?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
-    }
-
+    const CHECK_ATTR_BATCH_SIZE: usize = 256;
     let mut generated = HashSet::new();
-    let fields: Vec<&[u8]> = out.stdout.split(|byte| *byte == 0).collect();
-    for chunk in fields.chunks_exact(3) {
-        let path = String::from_utf8_lossy(chunk[0]);
-        let info = String::from_utf8_lossy(chunk[2]);
-        if info == "set" {
-            generated.insert(path.into_owned());
+
+    for batch in names
+        .iter()
+        .collect::<Vec<_>>()
+        .chunks(CHECK_ATTR_BATCH_SIZE)
+    {
+        let mut args = vec!["check-attr", "-z", "linguist-generated", "--"];
+        args.extend(batch.iter().copied().map(String::as_str));
+
+        let out = Command::new("git")
+            .args(&args)
+            .current_dir(project_root)
+            .output()
+            .context("git check-attr")?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
+        }
+
+        let fields: Vec<&[u8]> = out.stdout.split(|byte| *byte == 0).collect();
+        for chunk in fields.chunks_exact(3) {
+            let path = String::from_utf8_lossy(chunk[0]);
+            let info = String::from_utf8_lossy(chunk[2]);
+            if info == "set" {
+                generated.insert(path.into_owned());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- skip lint targets that are marked as generated in git attributes
- keep Flint scoped to tracked files and preserve Flint-managed built-in excludes
- document that generated files should be marked in `.gitattributes` instead of Flint-only config when possible

## Why
Generated files should not be part of ordinary lint runs, and storing that intent in git attributes lets GitHub and other tooling reuse the same metadata.

## Root cause
Flint already limited full runs to `git ls-files`, but generic lint filtering did not consult git attributes for generated files, so tracked generated files could still be linted unless they were excluded in Flint-specific config.

## Validation
- `cargo test`
- `mise run lint:fix`
