### PR TITLE
docs: document quiet-by-default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Flint is a fast, simple lint runner that doesn't slow down your AI coding.
   repos can stick with the generated defaults
 - **Opinionated config** — Flint chooses canonical config filenames per linter,
   while still letting you keep them in a directory such as `.github/config`
-- **AI-friendly** — fix silently, surface only what needs review
+- **AI-friendly** — quiet by default: clean runs print nothing, `--fix`
+  surfaces only what needs review
 - **Separated ownership** — dedicated linters and formatters own their file
   types to avoid overlapping rules and editor-config conflicts
 - **Predictable and updatable linter versions** — lint behavior stays stable
@@ -98,8 +99,20 @@ For normal local use, run:
 mise run lint:fix
 ```
 
-Flint fixes what it can, tells you when everything is already good, and tells
-you what still needs review.
+Flint is built to be quiet. A clean run prints nothing. `--fix` silently fixes
+what it can and prints only what still needs review:
+
+```text
+[shellcheck]
+
+In bad.sh line 2:
+echo $1
+     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+...
+flint: fixed: cargo-fmt — commit before pushing | review: shellcheck
+```
+
+Terse enough for AI agents, nice for humans too.
 
 **By default, Flint checks only changed files.** Use `--full` to check every
 matching file.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Flint is a fast, simple lint runner that doesn't slow down your AI coding.
 - **Opinionated config** — Flint chooses canonical config filenames per linter,
   while still letting you keep them in a directory such as `.github/config`
 - **AI-friendly** — quiet by default: clean runs print nothing, `--fix`
-  surfaces only what needs review
+  surfaces only what still needs action
 - **Separated ownership** — dedicated linters and formatters own their file
   types to avoid overlapping rules and editor-config conflicts
 - **Predictable and updatable linter versions** — lint behavior stays stable
@@ -100,7 +100,8 @@ mise run lint:fix
 ```
 
 Flint is built to be quiet. A clean run prints nothing. `--fix` silently fixes
-what it can and prints only what still needs review:
+what it can and prints what still needs action — review items plus a reminder
+to commit any fixes:
 
 ```text
 [shellcheck]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,11 +17,10 @@ it do not need to re-learn the interface.
 Flint is built to be quiet so AI agents (and humans) don't have to read pages
 of linter output to find the actionable bit:
 
-- **Clean run** — no output. Flint is fast enough that the absence of a crash
-  is the feedback.
-- **`--fix`** — silently fixes what it can, prints only what still needs human
-  review, and ends with a one-line summary naming each check and its state
-  (`fixed`, `review`, `partial`).
+- **Clean run** — no output. Same under `--fix` when nothing needed fixing.
+- **`--fix`** — silently fixes what it can, prints review-required output, and
+  ends with a one-line summary of the non-clean checks and their state
+  (`fixed`, `review`, `partial`). Fully-clean `--fix` runs print nothing.
 
 Example `--fix` output:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,6 +12,29 @@ Commands and flags follow
 [golangci-lint](https://golangci-lint.run/) conventions. Teams already using
 it do not need to re-learn the interface.
 
+## Output
+
+Flint is built to be quiet so AI agents (and humans) don't have to read pages
+of linter output to find the actionable bit:
+
+- **Clean run** — no output. Flint is fast enough that the absence of a crash
+  is the feedback.
+- **`--fix`** — silently fixes what it can, prints only what still needs human
+  review, and ends with a one-line summary naming each check and its state
+  (`fixed`, `review`, `partial`).
+
+Example `--fix` output:
+
+```text
+[shellcheck]
+
+In bad.sh line 2:
+echo $1
+     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+...
+flint: fixed: cargo-fmt — commit before pushing | review: shellcheck
+```
+
 ## `flint run` flags
 
 <!-- run-flags-start -->


### PR DESCRIPTION
## Summary

- README "AI-friendly" bullet broadened to mention silent-on-clean alongside `--fix` review surfacing
- README Using section rewritten with a concrete `--fix` example
- New `## Output` section in `docs/cli.md` before the flag table, capturing the same story as design context for the flags

## Why

The "quiet by default" behavior is one of Flint's nicer properties for both AI agents and humans, but it was buried — the README hinted at it via `--fix`, and `cli.md` only showed it implicitly in flag descriptions. This makes it discoverable.

`--short` intentionally not mentioned since its future is uncertain.

## Test plan

- [ ] Skim rendered README on GitHub
- [ ] Skim rendered cli.md on GitHub