### PR TITLE
chore: remove deprecated setting

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -1,6 +1,5 @@
 [settings]
 exclude = ["CHANGELOG.md", "tests/cases/**"]
-setup_migration_version = 2
 
 [checks.renovate-deps]
 exclude_managers = ["github-actions", "github-runners", "cargo"]


### PR DESCRIPTION
Lint fail (old url) is fixed in https://github.com/grafana/flint/pull/314
