### PR TITLE
fix: accept normalized Renovate currentVersion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,10 @@ jobs:
 
       - name: Test
         run: mise run test
+
+      - name: Live Renovate regression
+        if: runner.os == 'Linux'
+        env:
+          FLINT_LIVE_RENOVATE_TESTS: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: mise exec -- cargo test -q renovate_deps_live_accepts_normalized_current_version -- --nocapture

--- a/src/linters/renovate_deps/rules.rs
+++ b/src/linters/renovate_deps/rules.rs
@@ -154,9 +154,15 @@ pub(crate) fn extract_version_mismatches(
             continue;
         };
 
-        let extracted = extract_version_value(extract_version, current_version)
-            .with_context(|| format!("failed to evaluate extractVersion for dep {dep_name:?}"))?;
-        if extracted.as_deref() == Some(current_value) {
+        let extract_version_regex = compile_extract_version(extract_version)
+            .with_context(|| format!("failed to compile extractVersion for dep {dep_name:?}"))?;
+        let extracted = extract_version_value(&extract_version_regex, current_version);
+        if extract_version_is_consistent(
+            &extract_version_regex,
+            current_value,
+            current_version,
+            extracted.as_deref(),
+        ) {
             continue;
         }
 
@@ -175,6 +181,31 @@ pub(crate) fn extract_version_mismatches(
     }
 
     Ok(mismatches)
+}
+
+fn extract_version_is_consistent(
+    extract_version_regex: &Regex,
+    current_value: &str,
+    current_version: &str,
+    extracted_from_current_version: Option<&str>,
+) -> bool {
+    if extracted_from_current_version == Some(current_value) {
+        return true;
+    }
+
+    // Renovate's version fields are manager/datasource dependent. Some lookup
+    // results expose `currentVersion` as the normalized version after
+    // `extractVersion` has already been applied rather than as the raw upstream
+    // tag. In that shape, a valid `extractVersion` may no longer match
+    // `currentVersion` directly.
+    if current_version == current_value {
+        return true;
+    }
+
+    // Other results keep the exact file token in currentValue (e.g. `v0.11.0`)
+    // and put the normalized extracted value in currentVersion (`0.11.0`).
+    // Validate that direction too before reporting a stale extractVersion.
+    extract_version_value(extract_version_regex, current_value).as_deref() == Some(current_version)
 }
 
 pub(crate) fn validate_extract_version_consistency(snapshot: &Snapshot) -> anyhow::Result<()> {
@@ -245,16 +276,16 @@ fn infer_extract_version_from_current(
     ))
 }
 
-fn extract_version_value(
-    extract_version: &str,
-    current_version: &str,
-) -> anyhow::Result<Option<String>> {
+fn compile_extract_version(extract_version: &str) -> anyhow::Result<Regex> {
     let normalized = extract_version.replace("(?<", "(?P<");
-    let regex = Regex::new(&normalized)?;
-    Ok(regex
-        .captures(current_version)
+    Ok(Regex::new(&normalized)?)
+}
+
+fn extract_version_value(regex: &Regex, value: &str) -> Option<String> {
+    regex
+        .captures(value)
         .and_then(|captures| captures.name("version"))
-        .map(|version| version.as_str().to_string()))
+        .map(|version| version.as_str().to_string())
 }
 
 impl ComparablePackageRule {

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -568,6 +568,48 @@ fn validate_extract_version_consistency_accepts_matching_extraction() {
 }
 
 #[test]
+fn validate_extract_version_consistency_accepts_normalized_current_version() {
+    let snap = Snapshot {
+        meta: [(
+            "actionlint".to_string(),
+            DepMeta {
+                package_name: Some("rhysd/actionlint".to_string()),
+                datasource: Some("github-releases".to_string()),
+                current_value: Some("1.7.12".to_string()),
+                current_version: Some("1.7.12".to_string()),
+                extract_version: Some("^v(?<version>\\S+)".to_string()),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        files: dep_files(&[("mise.toml", &[("mise", &["actionlint"])])]),
+    };
+
+    assert!(validate_extract_version_consistency(&snap).is_ok());
+}
+
+#[test]
+fn validate_extract_version_consistency_accepts_normalized_prefixed_current_value() {
+    let snap = Snapshot {
+        meta: [(
+            "shellcheck".to_string(),
+            DepMeta {
+                package_name: Some("koalaman/shellcheck".to_string()),
+                datasource: Some("github-releases".to_string()),
+                current_value: Some("v0.11.0".to_string()),
+                current_version: Some("0.11.0".to_string()),
+                extract_version: Some("^v(?<version>\\S+)".to_string()),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        files: dep_files(&[("mise.toml", &[("mise", &["shellcheck"])])]),
+    };
+
+    assert!(validate_extract_version_consistency(&snap).is_ok());
+}
+
+#[test]
 fn validate_extract_version_consistency_flags_mismatch() {
     let snap = Snapshot {
         meta: [(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -363,6 +363,80 @@ biome = "2.4.12"
     );
 }
 
+// Live regression test using the real Renovate binary. It is skipped by default
+// for local `cargo test` because it requires network access, Renovate on PATH,
+// and a GitHub token. CI opts in with FLINT_LIVE_RENOVATE_TESTS=1.
+#[cfg(unix)]
+#[test]
+fn renovate_deps_live_accepts_normalized_current_version() {
+    if std::env::var("FLINT_LIVE_RENOVATE_TESTS").as_deref() != Ok("1") {
+        eprintln!("skipping live Renovate test; set FLINT_LIVE_RENOVATE_TESTS=1 to run");
+        return;
+    }
+
+    let token =
+        std::env::var("GITHUB_TOKEN").expect("set GITHUB_TOKEN before running live Renovate tests");
+
+    let repo = git_repo();
+
+    std::fs::write(
+        repo.path().join("mise.toml"),
+        r#"[tools]
+actionlint = "1.7.12"
+shellcheck = "v0.11.0"
+"npm:renovate" = "43.150.0"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        repo.path().join("renovate.json5"),
+        r#"{ extends: ["config:recommended"] }
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(repo.path())
+        .output()
+        .expect("failed to spawn git add");
+    assert!(
+        out.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let out = Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(repo.path())
+        .output()
+        .expect("failed to spawn git commit");
+    assert!(
+        out.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = flint_with_env(
+        &["run", "--full", "--fix", "renovate-deps"],
+        repo.path(),
+        &[("GITHUB_TOKEN", &token)],
+    );
+    let output = combined_output(&out);
+    assert!(
+        out.status.code() == Some(1),
+        "expected flint --fix to report changes needed:\n{output}"
+    );
+    assert!(
+        output.contains("fixed: renovate-deps"),
+        "expected renovate-deps to accept Renovate's normalized currentVersion output:\n{output}"
+    );
+
+    let snapshot = std::fs::read_to_string(repo.path().join("renovate-tracked-deps.json"))
+        .expect("renovate-tracked-deps.json should be written");
+    assert!(snapshot.contains(r#""actionlint""#), "{snapshot}");
+    assert!(snapshot.contains(r#""shellcheck""#), "{snapshot}");
+}
+
 // Unix-only: this e2e test creates fake linters as POSIX shell scripts and
 // marks them executable with Unix permissions.
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Accept Renovate lookup output where `currentVersion` is already normalized instead of the raw upstream tag.
- Keep stale `extractVersion` detection for genuinely mismatched raw-version cases.
- Add focused unit coverage plus a CI-enabled live Renovate regression.

## Validation

- `cargo test -q validate_extract_version_consistency -- --nocapture`
- `FLINT_LIVE_RENOVATE_TESTS=1 cargo test -q renovate_deps_live_accepts_normalized_current_version -- --nocapture`
- `mise run lint:fix`

## Notes

Root cause: `renovate-deps` assumed `currentVersion` was always the raw upstream tag. Newer/real Renovate mise lookup output can report normalized versions for GitHub release deps such as actionlint and shellcheck.
