### PR TITLE
fix: quiet and batch zizmor runs

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -209,7 +209,7 @@ Format Java code
 
 Lint Dockerfiles
 
-### [`ktlint`](https://pinterest.github.io/ktlint/latest/)
+### [`ktlint`](https://github.com/ktlint/ktlint)
 
 |          |                       |
 | -------- | --------------------- |
@@ -448,7 +448,7 @@ Validate XML files are well-formed
 | -------- | ----------------------------------------------------- |
 | Fix      | yes                                                   |
 | Binary   | `zizmor`                                              |
-| Scope    | [file](#scope-file)                                   |
+| Scope    | [files](#scope-files)                                 |
 | Patterns | `.github/workflows/*.yml .github/workflows/*.yaml`    |
 | Config   | [`zizmor.yml`](https://docs.zizmor.sh/configuration/) |
 

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -29,7 +29,7 @@ const GOOGLE_JAVA_FORMAT_URL: &str = "https://github.com/google/google-java-form
 const HADOLINT_URL: &str = "https://github.com/hadolint/hadolint";
 const HADOLINT_CONFIG_URL: &str =
     "https://github.com/hadolint/hadolint?tab=readme-ov-file#configure";
-const KTLINT_URL: &str = "https://pinterest.github.io/ktlint/latest/";
+const KTLINT_URL: &str = "https://github.com/ktlint/ktlint";
 const KTLINT_CONFIG_URL: &str =
     "https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/";
 const LYCHEE_URL: &str = "https://lychee.cli.rs/";
@@ -283,16 +283,22 @@ fn check_actionlint() -> Check {
 }
 
 fn check_zizmor() -> Check {
-    Check::file(
+    Check::files(
         "zizmor",
-        "zizmor {FILE}",
+        "zizmor {FILES}",
         &[".github/workflows/*.yml", ".github/workflows/*.yaml"],
     )
-    .fix("zizmor --fix {FILE}")
+    .fix("zizmor --fix {FILES}")
     .linter_config("zizmor.yml", "--config")
     .baseline_config(ConfigFile::config_dir("zizmor.yml"))
     .unsupported_configs(ZIZMOR_UNSUPPORTED_CONFIGS)
     .allow_baseline_overlap_in_unsupported_configs()
+    .nonverbose_filter_prefixes(&[
+        "No findings to report. Good job!",
+        "No fixes available to apply.",
+        " INFO zizmor:",
+        " INFO audit: zizmor:",
+    ])
     .project_url(ZIZMOR_URL)
     .config_doc_url(ZIZMOR_CONFIG_URL)
     .overview(

--- a/tests/cases/zizmor/failure-suppresses-clean-output/files/.github/workflows/one.yml
+++ b/tests/cases/zizmor/failure-suppresses-clean-output/files/.github/workflows/one.yml
@@ -1,0 +1,8 @@
+name: One
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo one

--- a/tests/cases/zizmor/failure-suppresses-clean-output/files/.github/workflows/two.yml
+++ b/tests/cases/zizmor/failure-suppresses-clean-output/files/.github/workflows/two.yml
@@ -1,0 +1,8 @@
+name: Two
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo two

--- a/tests/cases/zizmor/failure-suppresses-clean-output/files/mise.toml
+++ b/tests/cases/zizmor/failure-suppresses-clean-output/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+zizmor = "latest"

--- a/tests/cases/zizmor/failure-suppresses-clean-output/test.toml
+++ b/tests/cases/zizmor/failure-suppresses-clean-output/test.toml
@@ -1,0 +1,37 @@
+[expected]
+args = "run --full zizmor"
+exit = 1
+stderr = '''
+[zizmor]
+bad workflow: .github/workflows/two.yml
+
+flint: 1 check failed (zizmor)
+💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
+'''
+
+[expected.files]
+".zizmor-argc" = '''
+2
+'''
+
+[fake_bins]
+zizmor = '''
+#!/bin/sh
+set -eu
+printf '%s\n' "$#" > .zizmor-argc
+for file in "$@"; do
+  case "$file" in
+    *.github/workflows/two.yml)
+      printf '%s\n' 'bad workflow: .github/workflows/two.yml' >&2
+      exit 1
+      ;;
+  esac
+done
+printf '%s\n' 'No findings to report. Good job! (2 suppressed)'
+printf '%s\n' 'No findings to report. Good job! (2 suppressed)' >&2
+printf '%s\n' 'No findings to report. Good job! (6 suppressed)'
+printf '%s\n' 'No findings to report. Good job! (3 suppressed)' >&2
+printf '%s\n' ' INFO zizmor: 🌈 zizmor v1.25.2' >&2
+printf '%s\n' ' INFO audit: zizmor: 🌈 completed /repo/.github/workflows/one.yml' >&2
+exit 0
+'''

--- a/tests/cases/zizmor/failure/test.toml
+++ b/tests/cases/zizmor/failure/test.toml
@@ -14,8 +14,6 @@ warning[artipacked]: credential persistence through GitHub Actions artifacts
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
 
 3 findings (2 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
- INFO zizmor: 🌈 zizmor v1.25.2
- INFO audit: zizmor: 🌈 completed <REPO>/.github/workflows/artipacked.yml
 
 flint: 1 check failed (zizmor)
 💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.

--- a/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/.github/workflows/one.yml
+++ b/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/.github/workflows/one.yml
@@ -1,0 +1,8 @@
+name: One
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo one

--- a/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/.github/workflows/two.yml
+++ b/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/.github/workflows/two.yml
@@ -1,0 +1,8 @@
+name: Two
+on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo two

--- a/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/mise.toml
+++ b/tests/cases/zizmor/fix-failure-suppresses-clean-output/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+zizmor = "latest"

--- a/tests/cases/zizmor/fix-failure-suppresses-clean-output/test.toml
+++ b/tests/cases/zizmor/fix-failure-suppresses-clean-output/test.toml
@@ -1,0 +1,32 @@
+[expected]
+args = "run --full --fix zizmor"
+exit = 1
+stderr = '''
+[zizmor]
+bad workflow: .github/workflows/two.yml
+flint: review: zizmor
+'''
+
+[expected.files]
+".zizmor-argc" = '''
+3
+'''
+
+[fake_bins]
+zizmor = '''
+#!/bin/sh
+set -eu
+printf '%s\n' "$#" > .zizmor-argc
+for file in "$@"; do
+  case "$file" in
+    *.github/workflows/two.yml)
+      printf '%s\n' 'bad workflow: .github/workflows/two.yml' >&2
+      exit 1
+      ;;
+  esac
+done
+printf '%s\n' ' INFO zizmor: 🌈 zizmor v1.25.2' >&2
+printf '%s\n' ' INFO audit: zizmor: 🌈 completed /repo/.github/workflows/one.yml' >&2
+printf '%s\n' 'No fixes available to apply.'
+exit 0
+'''


### PR DESCRIPTION
## Summary

- Run `zizmor` once with all workflow files instead of spawning one process per workflow.
- Suppress clean `zizmor` success chatter in non-verbose runs while preserving diagnostics and raw `--verbose` output.
- Update generated linter docs and add fixture coverage for check and fix output.

## Validation

- `FLINT_CASES=zizmor cargo test -q cases -- --nocapture`
- `cargo test -q cases -- --nocapture`
- `mise run lint:fix`
- Verified against `prom_client_java`: `flint run --full zizmor` and `flint run --full --fix zizmor` exit 0 with no output.

## Notes

Root cause: Flint registered `zizmor` as file-scope, so repositories with many workflow files paid startup cost once per workflow and printed each clean invocation's chatter.
