### PR TITLE
docs: clarify Flint check model

### DIFF
--- a/.github/agents/knowledge/linters.md
+++ b/.github/agents/knowledge/linters.md
@@ -9,7 +9,7 @@ template vs native checks, fix outcomes, and Flint's boundaries — see
 
 ## Adding or changing a check
 
-Add an entry to `builtin()` in `src/registry.rs` using the
+Add an entry to `builtin()` in `src/registry/checks.rs` using the
 builder pattern:
 
 ```rust
@@ -80,7 +80,8 @@ run when changed, even if they are not passed via `.linter_config(...)`; for
 example, `editorconfig-checker` treats `.editorconfig` as a baseline config.
 
 For checks that need custom logic beyond a simple command template, add a
-module under `src/linters/` and use `CheckKind::Special`.
+module under `src/linters/` and register it with `Check::native(&CHECK_TYPE)`
+so the registry uses `CheckKind::Native`.
 
 ## Changed-files scoping
 

--- a/.github/agents/knowledge/linters.md
+++ b/.github/agents/knowledge/linters.md
@@ -1,4 +1,13 @@
-# Adding a New Linter
+# Linter implementation notes
+
+This article is for **agent implementation guidance** when editing Flint's
+check registry or adding custom linter behavior.
+
+For the higher-level, human-facing execution model — how checks become active,
+template vs native checks, fix outcomes, and Flint's boundaries — see
+`docs/check-model.md`.
+
+## Adding or changing a check
 
 Add an entry to `builtin()` in `src/registry.rs` using the
 builder pattern:
@@ -70,8 +79,8 @@ auto-discover a config that flint does not baseline or inject. Use
 run when changed, even if they are not passed via `.linter_config(...)`; for
 example, `editorconfig-checker` treats `.editorconfig` as a baseline config.
 
-For checks that need custom logic (not a simple command template), add a module
-under `src/linters/` and use `CheckKind::Special`.
+For checks that need custom logic beyond a simple command template, add a
+module under `src/linters/` and use `CheckKind::Special`.
 
 ## Changed-files scoping
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <p align="center">
   <a href="docs/cli.md">CLI reference</a> ·
+  <a href="docs/check-model.md">How checks work</a> ·
   <a href="docs/linters.md">Linters</a> ·
   <a href="docs/why.md">Why flint?</a> ·
   <a href="docs/alternatives.md">Alternatives</a>

--- a/docs/check-model.md
+++ b/docs/check-model.md
@@ -1,0 +1,162 @@
+# How Flint runs checks
+
+This page explains Flint's execution model: how checks become active, what kind
+of checks Flint supports, and where Flint stops.
+
+## Mental model
+
+Flint has a **built-in check registry** compiled into the binary.
+
+Each check in that registry describes:
+
+- its name
+- how it becomes active
+- which files it cares about
+- whether it supports fix mode
+- how Flint should run it
+
+At runtime, Flint combines that built-in registry with the consuming repo's:
+
+- `mise.toml`
+- `flint.toml`
+- tracked files and changed-file set
+- environment (for example local vs CI)
+
+Flint is **not** a generic per-repo command runner or plugin loader. That is an
+intentional boundary, not a temporary limitation: `mise` already provides the
+generic task-runner layer, while Flint focuses on curated lint and check
+orchestration. The extension point is the built-in registry plus repo
+configuration, not arbitrary commands declared in `flint.toml`.
+
+## How a check becomes active
+
+Most checks are **opt-in via `mise.toml`**.
+
+If a repo declares the tool a check expects, Flint considers that check active.
+If the tool is not declared, Flint skips the check.
+
+Examples:
+
+- declare `shellcheck` in `mise.toml` -> `shellcheck` becomes active
+- declare `aqua:owenlamont/ryl` -> `ryl` becomes active
+
+This is why Flint can stay quiet and fast: the repo chooses the toolchain, and
+Flint only runs checks the repo has explicitly installed.
+
+Some checks are exceptions:
+
+- **native config-driven checks** may be active based on config rather than an
+  external binary alone
+- **setup checks** such as `flint-setup` are special-purpose and may run even
+  though they are not ordinary linter binaries
+
+## Two execution models
+
+Flint supports two main kinds of checks.
+
+## Template checks
+
+Template checks run an external command from a command template.
+
+Typical examples:
+
+- `shellcheck`
+- `shfmt`
+- `rumdl`
+- `zizmor`
+
+Template checks declare:
+
+- a command for check mode
+- optionally a command for fix mode
+- a scope:
+  - **file**: one invocation per file
+  - **files**: one invocation with a file list
+  - **project**: one invocation with no file arguments
+
+This is the simplest model when a tool is already a good CLI and Flint mainly
+needs to handle:
+
+- file selection
+- config injection
+- quiet output
+- fix-mode orchestration
+
+## Native checks
+
+Native checks are **implemented in-process** inside Flint.
+
+Typical examples today:
+
+- `renovate-deps`
+- `lychee`
+- `license-header`
+- `flint-setup`
+
+Native checks can still invoke external binaries, but they are not limited to a
+single command template. They can do custom preparation and orchestration first.
+
+Use this model when the check needs behavior such as:
+
+- custom orchestration logic
+- richer config handling
+- multiple execution phases
+- custom relevance/baseline logic
+- fix behavior that is more nuanced than one command string
+
+In other words:
+
+- **template** = Flint runs a command
+- **native** = Flint runs custom Rust logic, which may itself run commands
+
+## Fix mode
+
+Flint has one `--fix` surface, but checks participate in it in two different
+ways:
+
+- template checks provide a fix command
+- native checks implement fix behavior in code
+
+Internally, Flint distinguishes outcomes such as:
+
+- **clean**
+- **fixed**
+- **review**
+- **partial**
+
+That lets Flint present one consistent user-facing `--fix` workflow even when
+the underlying tools have different capabilities.
+
+## What Flint is good at
+
+Flint works best as:
+
+- a fast runner over a curated set of checks
+- a consistent local + CI surface
+- a changed-file-aware orchestrator
+- a unified fix entrypoint
+
+## What Flint is not trying to be
+
+Flint is not intended to be:
+
+- a generic "run whatever commands the repo config says" wrapper
+- a plugin system that loads arbitrary repo-local check implementations
+- a replacement for every tool's own CLI
+
+That boundary is deliberate: Flint owns the execution model and built-in
+registry, while `mise` provides the generic task-runner layer and repos opt
+into Flint checks by declaring the toolchain and config they want.
+
+## Implication for new checks
+
+When deciding how to add a new check, use this rule of thumb:
+
+- choose a **template check** when the tool already has a clean CLI and Flint
+  mostly needs to handle scope, config, and fix wiring
+- choose a **native check** when the tool needs custom orchestration, custom
+  state handling, or in-process logic
+
+If the real logic lives elsewhere, the key question is not "can Flint call an
+external thing?" — it can — but "does this belong as a template command or as a
+native check with custom orchestration?"

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -475,7 +475,9 @@ whole project when it does run. `golangci-lint` is the exception — it uses
 ### Scope: native
 
 Implemented in-process rather than via a command template. These checks may run
-without file arguments or use custom orchestration logic.
+without file arguments or use custom orchestration logic. See
+[How Flint runs checks](check-model.md) for the higher-level model and when to
+choose native vs template checks.
 
 **`editorconfig-checker` defers to formatters**: `editorconfig-checker` runs on
 all files, but automatically skips file types owned by an active formatter. If


### PR DESCRIPTION
## Summary
- add a human-facing `docs/check-model.md` page that explains how Flint activates and runs checks
- link the new page from the README and from the native-scope section in `docs/linters.md`
- trim `.github/agents/knowledge/linters.md` so it stays focused on agent implementation guidance instead of duplicating the higher-level model

## Why
The new check-model page is a better canonical explanation for contributors and users. Keeping the knowledge doc agent-specific reduces duplication and lowers the chance that the two explanations drift.

## Impact
- humans get a clearer overview of template vs native checks and Flint's execution model
- agents still have a concise implementation-oriented guide for registry and linter changes

## Validation
- `mise run lint:fix`
