### PR TITLE
chore: use shared workflow for PR title lint

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,3 @@
----
 name: PR Title
 
 on:
@@ -13,6 +12,4 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - uses: grafana/shared-workflows/actions/lint-pr-title@0239db2665246f3b078d8d9166e4d8f09c071cae # lint-pr-title/v1.2.2


### PR DESCRIPTION
## What changed
- replaced `amannn/action-semantic-pull-request` in the PR title workflow
- switched to `grafana/shared-workflows/actions/lint-pr-title` pinned to immutable release `lint-pr-title/v1.2.2`

## Why
This is an explicit canary for the `security-hardening` shared-workflows replacement catalog.
It validates the non-Docker migration path first, using a very small isolated workflow.

## Impact
- keeps PR title linting in place
- moves the repo to a Grafana-maintained shared action
- gives us a concrete canary before considering broader rollout

## Validation
- reviewed the existing `grafana/flint` workflow shape
- verified the target shared action exists in `grafana/shared-workflows`
- no repo-specific runtime checks were run; this is a focused workflow-reference change
