### PR TITLE
docs: note zizmor drift from upstream tag movement

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -491,3 +491,13 @@ length**: today that means `rumdl` for `*.md`, `rustfmt` for `*.rs`, and
 intent instead of relying on checker-specific JSON excludes. If a matching
 section already exists, `flint init` rewrites its `max_line_length` to `off`
 instead of leaving a formatter-conflicting numeric value in place.
+
+**`zizmor` can drift without file changes**: zizmor's
+`ref-version-mismatch` audit resolves pinned action hashes against
+GitHub's tag API at run-time. When a maintainer moves a mutable tag
+(e.g. `v6` advances to a new patch), workflows pinned to the old
+commit but commented `# v6` become inconsistent without any local
+file change. Flint scans only files changed in the PR, so drift in
+untouched workflows stays invisible until something edits them.
+Run `flint run --full` periodically (e.g. weekly `schedule:` workflow)
+to catch this.

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -138,6 +138,20 @@ Format C# code
 
 Check files comply with EditorConfig settings
 
+`editorconfig-checker` defers to formatters: it runs on all files
+but automatically skips file types owned by an active formatter. If
+none of those formatters are installed, `editorconfig-checker` checks
+those files itself.
+
+Flint writes shared `.editorconfig` carve-outs for known
+formatter-owned line length: today that means `rumdl` for `*.md`,
+`rustfmt` for `*.rs`, and `google-java-format` for `*.java`. Those
+sections use `max_line_length = off` so editors and
+`editorconfig-checker` share the same intent instead of relying on
+checker-specific JSON excludes. If a matching section already
+exists, `flint init` rewrites its `max_line_length` to `off`
+instead of leaving a formatter-conflicting numeric value in place.
+
 ### `flint-setup`
 
 |          |                         |
@@ -453,6 +467,15 @@ Validate XML files are well-formed
 | Config   | [`zizmor.yml`](https://docs.zizmor.sh/configuration/) |
 
 Audit GitHub Actions workflows for security issues
+
+zizmor can drift without file changes: its `ref-version-mismatch`
+audit resolves pinned action hashes against GitHub's tag API at
+run-time. When a maintainer moves a mutable tag (e.g. `v6` advances
+to a new patch), workflows pinned to the old commit but commented
+`# v6` become inconsistent without any local file change. Flint
+scans only files changed in the PR, so drift in untouched workflows
+stays invisible until something edits them. Run `flint run --full`
+periodically (e.g. weekly `schedule:` workflow) to catch this.
 <!-- linter-details-end -->
 
 ## Scopes
@@ -478,26 +501,3 @@ Implemented in-process rather than via a command template. These checks may run
 without file arguments or use custom orchestration logic. See
 [How Flint runs checks](check-model.md) for the higher-level model and when to
 choose native vs template checks.
-
-**`editorconfig-checker` defers to formatters**: `editorconfig-checker` runs on
-all files, but automatically skips file types owned by an active formatter. If
-none of those formatters are installed, `editorconfig-checker` checks those
-files itself.
-
-**Flint writes shared `.editorconfig` carve-outs for known formatter-owned line
-length**: today that means `rumdl` for `*.md`, `rustfmt` for `*.rs`, and
-`google-java-format` for `*.java`. Those sections use
-`max_line_length = off` so editors and `editorconfig-checker` share the same
-intent instead of relying on checker-specific JSON excludes. If a matching
-section already exists, `flint init` rewrites its `max_line_length` to `off`
-instead of leaving a formatter-conflicting numeric value in place.
-
-**`zizmor` can drift without file changes**: zizmor's
-`ref-version-mismatch` audit resolves pinned action hashes against
-GitHub's tag API at run-time. When a maintainer moves a mutable tag
-(e.g. `v6` advances to a new patch), workflows pinned to the old
-commit but commented `# v6` become inconsistent without any local
-file change. Flint scans only files changed in the PR, so drift in
-untouched workflows stays invisible until something edits them.
-Run `flint run --full` periodically (e.g. weekly `schedule:` workflow)
-to catch this.

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -308,6 +308,16 @@ fn check_zizmor() -> Check {
         None,
     )
     .desc("Audit GitHub Actions workflows for security issues")
+    .docs(
+        "zizmor can drift without file changes: its `ref-version-mismatch`\n\
+        audit resolves pinned action hashes against GitHub's tag API at\n\
+        run-time. When a maintainer moves a mutable tag (e.g. `v6` advances\n\
+        to a new patch), workflows pinned to the old commit but commented\n\
+        `# v6` become inconsistent without any local file change. Flint\n\
+        scans only files changed in the PR, so drift in untouched workflows\n\
+        stays invisible until something edits them. Run `flint run --full`\n\
+        periodically (e.g. weekly `schedule:` workflow) to catch this.",
+    )
     .style()
 }
 
@@ -387,6 +397,21 @@ fn check_editorconfig_checker() -> Check {
             Some("EditorConfig compliance"),
         )
         .desc("Check files comply with EditorConfig settings")
+        .docs(
+            "`editorconfig-checker` defers to formatters: it runs on all files\n\
+            but automatically skips file types owned by an active formatter. If\n\
+            none of those formatters are installed, `editorconfig-checker` checks\n\
+            those files itself.\n\
+            \n\
+            Flint writes shared `.editorconfig` carve-outs for known\n\
+            formatter-owned line length: today that means `rumdl` for `*.md`,\n\
+            `rustfmt` for `*.rs`, and `google-java-format` for `*.java`. Those\n\
+            sections use `max_line_length = off` so editors and\n\
+            `editorconfig-checker` share the same intent instead of relying on\n\
+            checker-specific JSON excludes. If a matching section already\n\
+            exists, `flint init` rewrites its `max_line_length` to `off`\n\
+            instead of leaving a formatter-conflicting numeric value in place.",
+        )
 }
 
 fn check_golangci_lint() -> Check {


### PR DESCRIPTION
## Summary

- Document that zizmor's `ref-version-mismatch` audit depends on upstream tag state, so untouched workflows can become inconsistent without any local file change.
- Recommend a periodic `flint run --full` (e.g. weekly `schedule:`) to catch drift that the changed-files scan misses.

## Test plan

- [x] `mise run lint:fix` clean