### PR TITLE
fix(renovate-deps): normalize tracked snapshot ordering

### DIFF
--- a/src/linters/renovate_deps/snapshot.rs
+++ b/src/linters/renovate_deps/snapshot.rs
@@ -51,6 +51,14 @@ impl Snapshot {
         self.files.is_empty()
     }
 
+    pub(crate) fn normalize(&mut self) {
+        for managers in self.files.values_mut() {
+            for deps in managers.values_mut() {
+                deps.sort();
+            }
+        }
+    }
+
     pub(crate) fn strip_lookup_meta(&mut self) {
         for meta in self.meta.values_mut() {
             meta.clear_version_context();
@@ -60,13 +68,16 @@ impl Snapshot {
 
 pub(crate) fn read_snapshot(contents: &str) -> anyhow::Result<Snapshot> {
     let parsed: serde_json::Value = serde_json::from_str(contents)?;
-    if parsed.get("files").is_some() || parsed.get("meta").is_some() {
-        return Ok(serde_json::from_value(parsed)?);
-    }
-    Ok(Snapshot {
-        meta: BTreeMap::new(),
-        files: serde_json::from_value(parsed)?,
-    })
+    let mut snapshot = if parsed.get("files").is_some() || parsed.get("meta").is_some() {
+        serde_json::from_value(parsed)?
+    } else {
+        Snapshot {
+            meta: BTreeMap::new(),
+            files: serde_json::from_value(parsed)?,
+        }
+    };
+    snapshot.normalize();
+    Ok(snapshot)
 }
 
 /// Parses Renovate's NDJSON log and returns the dependency snapshot.
@@ -243,14 +254,21 @@ fn collapse_unique(values: BTreeSet<String>) -> Option<String> {
 }
 
 pub(crate) fn write_snapshot(path: &Path, deps: &Snapshot) -> anyhow::Result<()> {
-    let json = serde_json::to_string_pretty(deps)?;
+    let mut deps = deps.clone();
+    deps.normalize();
+    let json = serde_json::to_string_pretty(&deps)?;
     std::fs::write(path, json + "\n")?;
     Ok(())
 }
 
 pub(crate) fn unified_diff(old: &Snapshot, new: &Snapshot, committed_display: &str) -> String {
-    let old_text = serde_json::to_string_pretty(old).unwrap_or_default() + "\n";
-    let new_text = serde_json::to_string_pretty(new).unwrap_or_default() + "\n";
+    let mut old = old.clone();
+    old.normalize();
+    let mut new = new.clone();
+    new.normalize();
+
+    let old_text = serde_json::to_string_pretty(&old).unwrap_or_default() + "\n";
+    let new_text = serde_json::to_string_pretty(&new).unwrap_or_default() + "\n";
 
     let diff = similar::TextDiff::from_lines(&old_text, &new_text);
     diff.unified_diff()

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -440,12 +440,53 @@ fn reads_legacy_snapshot_format() {
 }
 
 #[test]
+fn read_snapshot_normalizes_dep_order() {
+    let current = r#"{
+  "meta": {},
+  "files": {
+    "package.json": {
+      "npm": [
+        "zebra",
+        "alpha",
+        "moose"
+      ]
+    }
+  }
+}
+"#;
+    let snapshot = read_snapshot(current).unwrap();
+    assert_eq!(
+        snapshot.files,
+        dep_files(&[("package.json", &[("npm", &["alpha", "moose", "zebra"])])])
+    );
+}
+
+#[test]
 fn write_snapshot_ends_with_newline() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("out.json");
     write_snapshot(&path, &Snapshot::default()).unwrap();
     let contents = std::fs::read_to_string(&path).unwrap();
     assert!(contents.ends_with('\n'));
+}
+
+#[test]
+fn write_snapshot_serializes_canonical_dep_order() {
+    use std::collections::BTreeMap;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.json");
+    let deps = Snapshot {
+        meta: BTreeMap::new(),
+        files: dep_files(&[("package.json", &[("npm", &["zebra", "alpha", "moose"])])]),
+    };
+
+    write_snapshot(&path, &deps).unwrap();
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert!(contents.contains(
+        "\"npm\": [\n        \"alpha\",\n        \"moose\",\n        \"zebra\"\n      ]"
+    ));
 }
 
 #[test]

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -484,9 +484,11 @@ fn write_snapshot_serializes_canonical_dep_order() {
     write_snapshot(&path, &deps).unwrap();
 
     let contents = std::fs::read_to_string(&path).unwrap();
-    assert!(contents.contains(
-        "\"npm\": [\n        \"alpha\",\n        \"moose\",\n        \"zebra\"\n      ]"
-    ));
+    let written: serde_json::Value = serde_json::from_str(&contents).unwrap();
+    assert_eq!(
+        written["files"]["package.json"]["npm"],
+        serde_json::json!(["alpha", "moose", "zebra"])
+    );
 }
 
 #[test]
@@ -1045,6 +1047,33 @@ fn unified_diff_header_uses_display_path() {
     let new = snapshot(&[("y", None, None)], &[("a.json", &[("npm", &["y"])])]);
     let diff = unified_diff(&old, &new, "renovate-tracked-deps.json");
     assert!(diff.contains("renovate-tracked-deps.json"));
+}
+
+#[test]
+fn unified_diff_ignores_dep_order_only_changes() {
+    let old = snapshot(
+        &[
+            ("alpha", None, None),
+            ("moose", None, None),
+            ("zebra", None, None),
+        ],
+        &[("package.json", &[("npm", &["zebra", "alpha", "moose"])])],
+    );
+    let new = snapshot(
+        &[
+            ("alpha", None, None),
+            ("moose", None, None),
+            ("zebra", None, None),
+        ],
+        &[("package.json", &[("npm", &["moose", "zebra", "alpha"])])],
+    );
+
+    let diff = unified_diff(&old, &new, ".github/renovate-tracked-deps.json");
+
+    assert!(
+        diff.is_empty(),
+        "ordering-only changes should not diff: {diff}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- normalize `renovate-tracked-deps.json` dependency ordering
- sort snapshot dependency arrays on read, write, and diff
- add regression coverage for canonical snapshot ordering

## Why
A downstream PR showed churn in `.github/renovate-tracked-deps.json` caused only by entry ordering. The snapshot format already stabilizes object keys, but dependency arrays could still preserve non-canonical order from existing files or comparisons. Normalizing the snapshot closes that gap and avoids ordering-only diffs.

## Validation
- `cargo test renovate_deps -- --nocapture`
- `mise run lint:fix`
