### PR TITLE
docs: link to Flint blog post

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -22,4 +22,6 @@ exclude = [
   "https://docs.google.com/.*",
   # Release Please generates compare links for future releases that 404 until the release is published
   "https://github.com/.*/compare/.*",
+  # Medium blocks automated link checkers with 403
+  "https://medium.com/.*",
 ]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 Flint is a fast, simple lint runner that doesn't slow down your AI coding.
 
+> 📖 Read the blog post: [Flint — a linter setup that doesn't slow down your AI agent](https://medium.com/grafana-labs/flint-a-linter-setup-that-doesnt-slow-down-your-ai-agent-e3a85044c4c2)
+
 - **Fast** — native execution (no Docker), parallel, diff-aware
   (changed files only), opt-in (undeclared tools don't run), small binary
   cached by mise

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,5 +1,7 @@
 # Why Flint
 
+> 📖 Blog post: [Flint — a linter setup that doesn't slow down your AI agent](https://medium.com/grafana-labs/flint-a-linter-setup-that-doesnt-slow-down-your-ai-agent-e3a85044c4c2)
+
 Flint exists to make repository linting fast, predictable, and easy to keep
 consistent between local development, hooks, CI, and agentic workflows.
 


### PR DESCRIPTION
## Summary
- Add prominent link to the [Flint blog post](https://medium.com/grafana-labs/flint-a-linter-setup-that-doesnt-slow-down-your-ai-agent-e3a85044c4c2) in `README.md` and `docs/why.md`
- Exclude `medium.com/*` from lychee (returns 403 to bots)

## Test plan
- [x] `mise run lint:fix` passes