### PR TITLE
fix(renovate-deps): keep deps with skipReason=invalid-version

### DIFF
--- a/src/linters/renovate_deps/snapshot.rs
+++ b/src/linters/renovate_deps/snapshot.rs
@@ -3,7 +3,12 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
 
 const PACKAGE_FILES_MSGS: &[&str] = &["Extracted dependencies", "packageFiles with updates"];
-const SKIP_REASONS: &[&str] = &["contains-variable", "invalid-value", "invalid-version"];
+// `invalid-version` is intentionally NOT filtered: it is set at lookup time when
+// Renovate's versioning rejects the resolved `currentVersion` (e.g. mise.lock
+// forwarding `temurin-*` as currentVersion for java-jdk). The dep is still
+// declared in the config and must remain tracked; filtering it here caused
+// `--fix` (lookup) to silently drop deps that verify (extract) keeps.
+const SKIP_REASONS: &[&str] = &["contains-variable", "invalid-value"];
 
 /// `{file_path: {manager: [dep_name, ...]}}` — all collections sorted.
 pub(crate) type DepFiles = BTreeMap<String, BTreeMap<String, Vec<String>>>;

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -291,10 +291,21 @@ fn deps_are_sorted() {
 #[test]
 fn filters_skip_reasons() {
     let log = log(
-        r#"{"npm":[{"packageFile":"package.json","deps":[{"depName":"keep"},{"depName":"bad1","skipReason":"contains-variable"},{"depName":"bad2","skipReason":"invalid-value"},{"depName":"bad3","skipReason":"invalid-version"}]}]}"#,
+        r#"{"npm":[{"packageFile":"package.json","deps":[{"depName":"keep"},{"depName":"bad1","skipReason":"contains-variable"},{"depName":"bad2","skipReason":"invalid-value"}]}]}"#,
     );
     let result = extract_deps(&log, &[]).unwrap();
     assert_eq!(result.files["package.json"]["npm"], vec!["keep"]);
+}
+
+#[test]
+fn invalid_version_is_kept() {
+    // Lookup-time versioning failures (e.g. java-jdk `temurin-*` currentVersion
+    // rejected by workarounds:javaLTSVersions regex) must not drop the dep.
+    let log = log(
+        r#"{"mise":[{"packageFile":"mise.toml","deps":[{"depName":"java","skipReason":"invalid-version"}]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+    assert_eq!(result.files["mise.toml"]["mise"], vec!["java"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- drop `invalid-version` from `SKIP_REASONS` so lookup-mode versioning failures don't silently delete deps from the tracked snapshot

## Why
`flint run --fix renovate-deps` uses `--dry-run=lookup` and applies package versioning. When Renovate's `workarounds:javaLTSVersions` preset assigns regex versioning to `java-jdk` and `mise.lock` forwards a vendor-prefixed `currentVersion` (e.g. `temurin-25.0.3+9.0.LTS`, `oracle-graalvm-25.0.1`), Renovate marks the dep `skipReason: invalid-version`. Flint then dropped the dep, so `--fix` deleted `java` from `.github/renovate-tracked-deps.json` while the non-fix path (extract) kept it.

Reproduced in [prometheus/client_java](https://github.com/prometheus/client_java): switching the OATs entry to the aqua backend triggered snapshot regeneration and silently removed `java` from every `.mise/envs/*/mise.toml` entry.

`invalid-version` only indicates that Renovate's versioning can't compute an update — the dep is still declared in the config. `contains-variable` / `invalid-value` remain filtered because those are extract-time indicators that the value is unresolvable.

### Why it stays hidden on clean trees
The fix flow in `main.rs` runs legacy checks as verify-then-fix:
1. verify pass with `fix: false` → `--dry-run=extract` → no versioning applied → java survives → snapshot matches committed → `r.ok = true`
2. because verify passed, the check is never partitioned into `fixable`, so the lookup-based fix pass never runs

So on a clean tree (even with `--full`) only the extract call happens and the bug is invisible. It only triggers when the verify pass finds a mismatch — e.g. any `mise.toml` change — and the fix pass then regenerates via lookup, at which point `invalid-version` on java silently deletes it from the snapshot.

## Test plan
- [x] `cargo test` (renovate_deps unit tests, plus new `invalid_version_is_kept` case)
- [x] rebuilt binary against prometheus/client_java: the aqua/OATs swap no longer deletes `java` from the snapshot