### PR TITLE
fix: avoid Windows arg-length limits in git check-attr and Scope::Files checks

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Genuine (misspelled) Win32 error constant name, not a typo of "exceed".
+exced = "exced"

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use std::collections::{BTreeSet, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::config::Config;
 use crate::linters::renovate_deps::COMMITTED_PATHS;
@@ -199,34 +200,49 @@ fn generated_paths(project_root: &Path, names: &BTreeSet<String>) -> Result<Hash
         return Ok(HashSet::new());
     }
 
-    const CHECK_ATTR_BATCH_SIZE: usize = 256;
-    let mut generated = HashSet::new();
+    // Feed paths via stdin (`--stdin -z`) instead of as CLI args. Passing many/long paths as
+    // argv batches hit Windows' ~32KB CreateProcess command-line limit on repos with long paths
+    // (os error 206, ERROR_FILENAME_EXCED_RANGE) even with modest batch sizes; stdin has no such
+    // limit on any platform.
+    let mut child = Command::new("git")
+        .args(["check-attr", "--stdin", "-z", "linguist-generated"])
+        .current_dir(project_root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("git check-attr")?;
 
-    for batch in names
-        .iter()
-        .collect::<Vec<_>>()
-        .chunks(CHECK_ATTR_BATCH_SIZE)
-    {
-        let mut args = vec!["check-attr", "-z", "linguist-generated", "--"];
-        args.extend(batch.iter().copied().map(String::as_str));
-
-        let out = Command::new("git")
-            .args(&args)
-            .current_dir(project_root)
-            .output()
-            .context("git check-attr")?;
-        if !out.status.success() {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
+    // Write on a separate thread: git may start writing output before we finish writing input,
+    // and the stdout pipe can fill up (typical OS pipe buffers are 4-64KB) well before all paths
+    // are written for a large repo, which would deadlock if done sequentially on this thread.
+    let mut stdin = child.stdin.take().expect("stdin was piped");
+    let names_for_writer: Vec<String> = names.iter().cloned().collect();
+    let writer = std::thread::spawn(move || -> std::io::Result<()> {
+        for name in &names_for_writer {
+            stdin.write_all(name.as_bytes())?;
+            stdin.write_all(b"\0")?;
         }
+        Ok(())
+    });
 
-        let fields: Vec<&[u8]> = out.stdout.split(|byte| *byte == 0).collect();
-        for chunk in fields.chunks_exact(3) {
-            let path = String::from_utf8_lossy(chunk[0]);
-            let info = String::from_utf8_lossy(chunk[2]);
-            if matches!(info.as_ref(), "set" | "true") {
-                generated.insert(path.into_owned());
-            }
+    let out = child.wait_with_output().context("git check-attr")?;
+    writer
+        .join()
+        .expect("git check-attr stdin writer thread panicked")
+        .context("git check-attr: writing stdin")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
+    }
+
+    let mut generated = HashSet::new();
+    let fields: Vec<&[u8]> = out.stdout.split(|byte| *byte == 0).collect();
+    for chunk in fields.chunks_exact(3) {
+        let path = String::from_utf8_lossy(chunk[0]);
+        let info = String::from_utf8_lossy(chunk[2]);
+        if matches!(info.as_ref(), "set" | "true") {
+            generated.insert(path.into_owned());
         }
     }
 
@@ -382,5 +398,63 @@ mod tests {
             filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
 
         assert_eq!(files, vec![tmp.path().join("tracked.sh")]);
+    }
+
+    /// Regression test for os error 206 (ERROR_FILENAME_EXCED_RANGE) on Windows: the previous
+    /// implementation passed paths as CLI args in batches of 256, which overflowed Windows'
+    /// ~32KB CreateProcess command-line limit for repos with many/long paths (this is exactly
+    /// what broke on a real large checkout — see the PR this test was added in). Names here are
+    /// long enough that a single 256-path argv batch would total well over 32KB, so this test
+    /// would fail with os error 206 under the old implementation when run on Windows — this
+    /// crate's CI matrix (.github/workflows/test.yml) already runs `cargo test` on windows-2025,
+    /// so this test exercises the real failure mode there, not just on Linux/macOS where argv
+    /// limits are much higher and wouldn't have caught this. Also verifies large-N correctness
+    /// and that writing stdin doesn't deadlock against a filled stdout pipe.
+    #[test]
+    fn filter_names_handles_many_long_paths_via_stdin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        for args in [
+            ["init", "-b", "main"].as_slice(),
+            ["config", "user.email", "test@test.com"].as_slice(),
+            ["config", "user.name", "Test"].as_slice(),
+        ] {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(tmp.path())
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {:?} failed", args);
+        }
+
+        std::fs::write(
+            tmp.path().join(".gitattributes"),
+            "*.generated.txt linguist-generated=true\n",
+        )
+        .unwrap();
+
+        // Long names (well under the 255-char filesystem component limit) so even a single
+        // argv-based batch of 256 paths would total ~256 * 220 chars ~= 56KB — comfortably over
+        // Windows' ~32KB command-line limit, not just barely over it.
+        let long_prefix = "a".repeat(200);
+        let mut names = BTreeSet::new();
+        let mut expected_kept = Vec::new();
+        for i in 0..2000 {
+            let generated_name = format!("{long_prefix}-{i}.generated.txt");
+            std::fs::write(tmp.path().join(&generated_name), "generated\n").unwrap();
+            names.insert(generated_name);
+
+            let kept_name = format!("{long_prefix}-{i}.txt");
+            std::fs::write(tmp.path().join(&kept_name), "kept\n").unwrap();
+            names.insert(kept_name.clone());
+            expected_kept.push(tmp.path().join(kept_name));
+        }
+        expected_kept.sort();
+
+        let mut files =
+            filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
+        files.sort();
+
+        assert_eq!(files, expected_kept);
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -226,11 +226,14 @@ fn generated_paths(project_root: &Path, names: &BTreeSet<String>) -> Result<Hash
         Ok(())
     });
 
-    let out = child.wait_with_output().context("git check-attr")?;
-    writer
+    // Always join the writer before propagating any error, so it's never left detached: an
+    // early `?` return on a `wait_with_output` failure would otherwise skip the join below.
+    let wait_result = child.wait_with_output().context("git check-attr");
+    let write_result = writer
         .join()
-        .expect("git check-attr stdin writer thread panicked")
-        .context("git check-attr: writing stdin")?;
+        .expect("git check-attr stdin writer thread panicked");
+    let out = wait_result?;
+    write_result.context("git check-attr: writing stdin")?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         anyhow::bail!("git check-attr failed ({}): {}", out.status, stderr.trim());
@@ -411,7 +414,7 @@ mod tests {
     /// limits are much higher and wouldn't have caught this. Also verifies large-N correctness
     /// and that writing stdin doesn't deadlock against a filled stdout pipe.
     #[test]
-    fn filter_names_handles_many_long_paths_via_stdin() {
+    fn generated_paths_handles_many_long_paths_via_stdin() {
         let tmp = tempfile::TempDir::new().unwrap();
 
         for args in [
@@ -433,28 +436,27 @@ mod tests {
         )
         .unwrap();
 
-        // Long names (well under the 255-char filesystem component limit) so even a single
-        // argv-based batch of 256 paths would total ~256 * 220 chars ~= 56KB — comfortably over
+        // `git check-attr` matches paths against .gitattributes patterns regardless of whether
+        // the path exists on disk, so these names are synthetic (not created as real files) —
+        // this keeps the test from tripping Windows' legacy 260-char MAX_PATH limit on CI
+        // runners while still exercising long paths through the actual `git check-attr`
+        // subprocess. Long enough that a single argv-based batch of 256 paths (the old
+        // implementation's batch size) would total ~256 * 220 chars ~= 56KB — comfortably over
         // Windows' ~32KB command-line limit, not just barely over it.
         let long_prefix = "a".repeat(200);
         let mut names = BTreeSet::new();
-        let mut expected_kept = Vec::new();
+        let mut expected_generated = HashSet::new();
         for i in 0..2000 {
             let generated_name = format!("{long_prefix}-{i}.generated.txt");
-            std::fs::write(tmp.path().join(&generated_name), "generated\n").unwrap();
-            names.insert(generated_name);
+            names.insert(generated_name.clone());
+            expected_generated.insert(generated_name);
 
             let kept_name = format!("{long_prefix}-{i}.txt");
-            std::fs::write(tmp.path().join(&kept_name), "kept\n").unwrap();
-            names.insert(kept_name.clone());
-            expected_kept.push(tmp.path().join(kept_name));
+            names.insert(kept_name);
         }
-        expected_kept.sort();
 
-        let mut files =
-            filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
-        files.sort();
+        let generated = generated_paths(tmp.path(), &names).unwrap();
 
-        assert_eq!(files, expected_kept);
+        assert_eq!(generated, expected_generated);
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -401,29 +401,72 @@ fn build_invocations(
                 }
             }
             let edition_flag = resolve_cargo_edition_flag(project_root);
-            let files_arg: String = matched
-                .iter()
-                .map(|f| quote_path(f))
-                .collect::<Vec<_>>()
-                .join(" ");
-            let rel_files_arg: String = matched
-                .iter()
-                .map(|f| quote_path(f.strip_prefix(project_root).unwrap_or(f)))
-                .collect::<Vec<_>>()
-                .join(" ");
-            let cmd = cmd_template
-                .replace("{CARGO_EDITION_FLAG}", &edition_flag)
-                .replace("{FILES}", &files_arg)
-                .replace("{RELFILES}", &rel_files_arg)
-                .replace("{CONFIG_ARGS}", &rendered_config_args);
-            let argv = shell_words(cmd);
-            vec![if inject_config_args {
-                inject_config(argv, &config_args)
-            } else {
-                argv
-            }]
+            chunk_files_by_length(&matched, project_root)
+                .into_iter()
+                .map(|chunk| {
+                    let files_arg: String = chunk
+                        .iter()
+                        .map(|f| quote_path(f))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let rel_files_arg: String = chunk
+                        .iter()
+                        .map(|f| quote_path(f.strip_prefix(project_root).unwrap_or(f)))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let cmd = cmd_template
+                        .replace("{CARGO_EDITION_FLAG}", &edition_flag)
+                        .replace("{FILES}", &files_arg)
+                        .replace("{RELFILES}", &rel_files_arg)
+                        .replace("{CONFIG_ARGS}", &rendered_config_args);
+                    let argv = shell_words(cmd);
+                    if inject_config_args {
+                        inject_config(argv, &config_args)
+                    } else {
+                        argv
+                    }
+                })
+                .collect()
         }
     }
+}
+
+/// Maximum characters to put in a single `{FILES}`/`{RELFILES}` substitution. Chosen well under
+/// cmd.exe's ~8191-char command-line buffer — some `Scope::Files` checks are mise shims that
+/// `spawn_command` routes through `cmd.exe /C` on Windows, which is a tighter limit than
+/// `CreateProcessW`'s ~32KB — leaving headroom for the command template itself, quoting, and the
+/// other substitutions applied afterward (`{CONFIG_ARGS}`, `{CARGO_EDITION_FLAG}`).
+const MAX_FILES_ARG_CHARS: usize = 6000;
+
+/// Splits `files` into groups whose rendered `{FILES}`/`{RELFILES}` argument stays under
+/// [`MAX_FILES_ARG_CHARS`], so `Scope::Files` checks issue multiple invocations instead of one
+/// unbounded one. Without this, a large PR (or full run) touching many/long-path files could
+/// overflow Windows' command-line length limits — see the `git check-attr` bug this pattern was
+/// extracted from.
+fn chunk_files_by_length<'a>(files: &[&'a PathBuf], project_root: &Path) -> Vec<Vec<&'a PathBuf>> {
+    let mut chunks: Vec<Vec<&PathBuf>> = vec![];
+    let mut current: Vec<&PathBuf> = vec![];
+    let mut current_len = 0usize;
+
+    for f in files.iter().copied() {
+        // Use the longer of the absolute/quoted-relative representations as a conservative
+        // per-file length estimate, since the template may substitute either {FILES} or
+        // {RELFILES} (or both).
+        let abs_len = quote_path(f).len();
+        let rel_len = quote_path(f.strip_prefix(project_root).unwrap_or(f)).len();
+        let len = abs_len.max(rel_len) + 1; // +1 for the joining space
+
+        if !current.is_empty() && current_len + len > MAX_FILES_ARG_CHARS {
+            chunks.push(std::mem::take(&mut current));
+            current_len = 0;
+        }
+        current.push(f);
+        current_len += len;
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
 }
 
 /// Returns `--edition <edition>` if a Rust edition is declared in the project's
@@ -873,6 +916,19 @@ mod tests {
         }
     }
 
+    fn files_check(patterns: &'static [&'static str]) -> Check {
+        Check {
+            kind: CheckKind::Template {
+                check_cmd: "run-it {FILES}",
+                fix_cmd: "",
+                full_cmd: "",
+                full_fix_cmd: "",
+                scope: Scope::Files,
+            },
+            ..project_check(patterns)
+        }
+    }
+
     fn file_list(paths: &[&str]) -> FileList {
         FileList {
             files: paths
@@ -930,6 +986,61 @@ mod tests {
             Path::new("/repo"),
         );
         assert_eq!(inv, vec![vec!["run-it".to_string()]]);
+    }
+
+    /// Regression test for the same class of bug fixed in `git check-attr` (os error 206,
+    /// `ERROR_FILENAME_EXCED_RANGE` on Windows): `Scope::Files` checks used to join every
+    /// matched file into a single invocation with no length cap, which could overflow Windows'
+    /// command-line limits (cmd.exe's ~8191 chars, tighter than `CreateProcessW`'s ~32KB) for a
+    /// PR touching many/long-path files. Verifies `build_invocations` now splits into multiple
+    /// invocations that together cover every matched file exactly once, each within the cap.
+    #[test]
+    fn files_scope_batches_when_files_arg_would_be_too_long() {
+        let check = files_check(&["*.txt"]);
+        // Long-enough names that all 100 in one invocation would exceed MAX_FILES_ARG_CHARS.
+        let long_prefix = "a".repeat(200);
+        let paths: Vec<String> = (0..100).map(|i| format!("{long_prefix}-{i}.txt")).collect();
+        let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let fl = file_list(&path_refs);
+
+        let inv = build_invocations(
+            &check,
+            &fl,
+            false,
+            Path::new("/repo"),
+            &[],
+            Path::new("/repo"),
+        );
+
+        assert!(
+            inv.len() > 1,
+            "expected multiple invocations, got {}",
+            inv.len()
+        );
+        for argv in &inv {
+            let joined = argv.join(" ");
+            assert!(
+                joined.len() <= MAX_FILES_ARG_CHARS + 100,
+                "invocation exceeded length cap: {} chars",
+                joined.len()
+            );
+        }
+
+        // Every invocation must start with the binary name.
+        for argv in &inv {
+            assert_eq!(argv[0], "run-it");
+        }
+
+        // The union of files across all invocations must equal the original set exactly,
+        // with no duplicates or omissions.
+        let mut seen: Vec<String> = inv
+            .iter()
+            .flat_map(|argv| argv[1..].iter().cloned())
+            .collect();
+        seen.sort();
+        let mut expected: Vec<String> = paths.iter().map(|p| format!("/repo/{p}")).collect();
+        expected.sort();
+        assert_eq!(seen, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Found by @trask on Windows: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19183#issuecomment-4938019461

```
$ mise run lint:fix
[lint:fix] $ flint run --fix
Error: git check-attr

Caused by:
    The filename or extension is too long. (os error 206)
```

Two fixes for the same underlying bug class — passing many/long file paths as CLI args with no (or an inadequate) length cap, overflowing Windows' command-line length limits.

### 1. `git check-attr` (internal git-plumbing helper)
- `generated_paths()` passed candidate paths as CLI args to `git check-attr`, batched at 256 per invocation. On repos with many/long paths (e.g. `opentelemetry-java-instrumentation`, a deeply-nested Java monorepo) a batch can total tens of KB, exceeding Windows' ~32KB `CreateProcess` command-line limit (os error 206, `ERROR_FILENAME_EXCED_RANGE` — yes, that's the real Win32 constant's actual spelling; added a `_typos.toml` entry so `typos` stops "fixing" it to "EXCEED").
- Switches to `git check-attr --stdin -z`, writing paths to the child's stdin instead of argv — stdin has no OS command-line-length ceiling, so batching is no longer needed. Paths are written on a separate thread concurrently with reading stdout/stderr, since output can fill the OS pipe buffer before all paths are written, which would deadlock if done sequentially.

### 2. `Scope::Files` check invocations (general check-execution path)
While investigating, found the same bug class in `build_invocations()` — worse, actually, since it had **no** length cap at all (not even a fixed batch count):
- `{FILES}`/`{RELFILES}` was substituted with every matched file joined into one command. Many `Scope::Files` checks are mise shims routed through `cmd.exe /C` by `spawn_command`, and `cmd.exe`'s own command-line buffer caps at **~8191 chars** — tighter than `CreateProcessW`'s ~32KB.
- `google-java-format` (registered via `Check::files`, no `full_cmd` fallback) is directly exposed: `opentelemetry-java-instrumentation` has thousands of `.java` files with long nested paths, so a PR touching as few as ~50 matching files could already overflow the limit. `ryl`, `zizmor`, `xmllint`, `typos`, and `editorconfig-checker` are similarly exposed. `ktlint`/`dotnet-format` have a `full_cmd` fallback, but it only applies to whole-project ("full") runs, not the common PR-scoped changed-files case.
- Adds `chunk_files_by_length()`, splitting matched files into groups that keep the rendered `{FILES}`/`{RELFILES}` argument under a conservative 6000-char cap, issuing multiple invocations instead of one unbounded one. `run_invocations()` already loops over a list of invocations and combines their output, so no changes were needed there.

## Test plan
- [x] `check-attr`: regression test with long-enough paths that a single 256-path argv batch would total ~56KB (verified mathematically, comfortable margin over the 32KB limit)
- [x] `Scope::Files`: regression test constructing a check with enough long-named files that a single invocation would exceed the cap, verifying `build_invocations` splits into multiple invocations that together cover every matched file exactly once
- [x] Both: this crate's own CI matrix (`.github/workflows/test.yml`) already runs `cargo test` on `windows-2025`, so these tests exercise the real failure mode there — can't reproduce the literal Windows OS error from a Linux sandbox, so margins were verified by calculation rather than direct repro
- [x] `cargo build`, `cargo test` (272/273 pass; the one failure is a pre-existing environment gap — missing linter binaries on PATH in this sandbox, unrelated)
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] `mise exec -- typos .` clean