### PR TITLE
fix: discover flint project root from parent mise files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod files;
 mod hook;
 mod init;
 mod linters;
+mod project_root;
 mod registry;
 mod runner;
 mod setup;
@@ -138,9 +139,7 @@ fn use_filtered_run_policy(args: &RunArgs, explicit: bool, is_ci: bool) -> bool 
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let project_root = std::env::var("MISE_PROJECT_ROOT")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::env::current_dir().expect("cannot determine working directory"));
+    let project_root = project_root::detect();
     // Canonicalize to resolve symlinks (e.g. /private/... on macOS).
     // dunce::canonicalize strips the \\?\ verbatim prefix on Windows that
     // git and other tools don't handle.

--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -1,0 +1,102 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn detect() -> PathBuf {
+    let cwd = std::env::current_dir().expect("cannot determine working directory");
+    find(&cwd).unwrap_or(cwd)
+}
+
+fn find(start: &Path) -> Option<PathBuf> {
+    let mut first_mise = None;
+
+    for dir in start.ancestors() {
+        let path = dir.join("mise.toml");
+        if !path.is_file() {
+            continue;
+        }
+
+        if first_mise.is_none() {
+            first_mise = Some(dir.to_path_buf());
+        }
+
+        if mise_toml_declares_flint(&path) {
+            return Some(dir.to_path_buf());
+        }
+    }
+
+    first_mise
+}
+
+fn mise_toml_declares_flint(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = toml::from_str::<toml::Value>(&content) else {
+        return false;
+    };
+    let Some(tools) = value.get("tools").and_then(toml::Value::as_table) else {
+        return false;
+    };
+
+    tools
+        .keys()
+        .any(|key| crate::registry::is_flint_tool_key(key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find;
+
+    #[test]
+    fn prefers_parent_mise_toml_that_declares_flint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let nested = root.join("apps/service/src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("mise.toml"), "[tools]\npython = '3.12'\n").unwrap();
+        std::fs::write(
+            root.join("apps/service/mise.toml"),
+            "[tools]\n\"aqua:grafana/flint\" = '0.22.7'\n",
+        )
+        .unwrap();
+
+        let found = find(&nested);
+
+        assert_eq!(found, Some(root.join("apps/service")));
+    }
+
+    #[test]
+    fn falls_back_to_first_parent_mise_toml_without_flint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let nested = root.join("apps/service/src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("mise.toml"), "[tools]\npython = '3.12'\n").unwrap();
+        std::fs::write(
+            root.join("apps/service/mise.toml"),
+            "[tools]\nnode = '24'\n",
+        )
+        .unwrap();
+
+        let found = find(&nested);
+
+        assert_eq!(found, Some(root.join("apps/service")));
+    }
+
+    #[test]
+    fn recognizes_cargo_flint_key_from_any_github_owner() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let nested = root.join("apps/service/src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("mise.toml"), "[tools]\npython = '3.12'\n").unwrap();
+        std::fs::write(
+            root.join("apps/service/mise.toml"),
+            "[tools]\n\"cargo:https://github.com/trask/flint\" = { version = \"branch:fix-lychee-windows-arg-limit\", crate = \"flint\", bin = \"flint\" }\n",
+        )
+        .unwrap();
+
+        let found = find(&nested);
+
+        assert_eq!(found, Some(root.join("apps/service")));
+    }
+}

--- a/src/registry/mise.rs
+++ b/src/registry/mise.rs
@@ -166,11 +166,26 @@ fn flint_tool_identity(tools: &HashMap<String, String>) -> Option<String> {
         .min()
 }
 
-fn is_flint_tool_key(key: &str) -> bool {
-    key == "aqua:grafana/flint"
-        || key == "github:grafana/flint"
-        || key == "cargo:https://github.com/grafana/flint"
-        || key == "cargo:https://github.com/grafana/flint.git"
+pub(crate) fn is_flint_tool_key(key: &str) -> bool {
+    key == "aqua:grafana/flint" || github_backend_flint_key(key) || cargo_github_flint_key(key)
+}
+
+fn github_backend_flint_key(key: &str) -> bool {
+    key.strip_prefix("github:")
+        .is_some_and(is_github_owner_and_flint_repo)
+}
+
+fn cargo_github_flint_key(key: &str) -> bool {
+    key.strip_prefix("cargo:https://github.com/")
+        .is_some_and(is_github_owner_and_flint_repo_or_git)
+}
+
+fn is_github_owner_and_flint_repo(path: &str) -> bool {
+    matches!(path.split_once('/'), Some((owner, "flint")) if !owner.is_empty())
+}
+
+fn is_github_owner_and_flint_repo_or_git(path: &str) -> bool {
+    matches!(path.split_once('/'), Some((owner, "flint" | "flint.git")) if !owner.is_empty())
 }
 
 fn declared_tool_version<'a>(

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -46,5 +46,9 @@ pub fn linter_keys() -> std::collections::HashSet<&'static str> {
     keys
 }
 
+pub(crate) fn is_flint_tool_key(key: &str) -> bool {
+    mise::is_flint_tool_key(key)
+}
+
 #[cfg(test)]
 mod tests;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -298,9 +298,16 @@ shellcheck = "v0.11.0"
         stdout,
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(
-        stdout.contains("shellcheck") && stdout.contains("active"),
-        "expected shellcheck to be active; stdout:\n{}",
+    let shellcheck_row = stdout
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some("shellcheck"))
+        .unwrap_or_else(|| panic!("expected a shellcheck row; stdout:\n{}", stdout));
+    let columns: Vec<_> = shellcheck_row.split_whitespace().collect();
+    assert_eq!(
+        columns.get(2).copied(),
+        Some("active"),
+        "expected shellcheck to be active; row:\n{}\n\nstdout:\n{}",
+        shellcheck_row,
         stdout
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -8,7 +8,8 @@ use tempfile::TempDir;
 fn flint_with_env(args: &[&str], cwd: &Path, env: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_flint"));
     cmd.args(args)
-        .env("MISE_PROJECT_ROOT", cwd)
+        .env_remove("MISE_CONFIG_ROOT")
+        .env_remove("MISE_PROJECT_ROOT")
         .env_remove("FLINT_CONFIG_DIR")
         // Keep test output stable regardless of whether the outer runner is CI.
         .env_remove("CI")
@@ -272,6 +273,35 @@ printf '%s\n' '{"msg":"Extracted dependencies","packageFiles":{"mise":[{"package
         "expected stale renovate snapshot failure; stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn linters_detect_active_tools_from_nested_working_directory() {
+    let repo = git_repo();
+
+    std::fs::write(
+        repo.path().join("mise.toml"),
+        r#"[tools]
+shellcheck = "v0.11.0"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(repo.path().join("nested/deeper")).unwrap();
+
+    let out = flint_with_env(&["linters"], &repo.path().join("nested/deeper"), &[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "flint linters failed; stdout:\n{}\nstderr:\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("shellcheck") && stdout.contains("active"),
+        "expected shellcheck to be active; stdout:\n{}",
+        stdout
     );
 }
 


### PR DESCRIPTION
## What changed
- discover Flint's project root by walking parent directories for `mise.toml`
- prefer the nearest parent `mise.toml` that explicitly declares Flint
- otherwise fall back to the first parent `mise.toml`
- add tests covering Flint-aware parent selection, fallback behavior, and nested-directory e2e invocation

## Why
Running `flint` from a subdirectory could miss active linters because root selection depended on the current working directory instead of the consuming repo's nearest relevant `mise.toml`.

## Impact
- `flint` now works more predictably from nested directories in consumer repos
- fork-based cargo pins such as `cargo:https://github.com/trask/flint` are recognized for branch-testing setups

## Validation
- `cargo test`
- `mise run lint:fix`
