### PR TITLE
docs: add local flint testing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,13 @@ cargo run -- run --fix
 
 ## Testing an unreleased branch in a consumer repo
 
-If you do **not** have Flint checked out locally and want to test a branch in a
-consumer repo, pin a cargo git dependency in that repo's `mise.toml`:
+If you do **not** have Flint checked out locally and want to test an unreleased
+Flint branch in a consumer repo, pin a cargo git dependency in that repo's
+`mise.toml`:
 
 ```toml
 [tools]
-"cargo:https://github.com/trask/flint" = { version = "branch:fix-lychee-windows-arg-limit", crate = "flint", bin = "flint" }
+"cargo:https://github.com/grafana/flint" = "rev:<git-ref>"
 ```
 
-That `trask/flint` example is just a fork used for branch testing; use your own
-fork/branch as needed.
+Replace `<git-ref>` with the branch, tag, or commit you want to test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Flint
+
+## Local development
+
+If you are working on Flint itself, the normal local workflow is:
+
+```bash
+cargo test
+mise run lint:fix
+```
+
+To run a narrower fixture subset while iterating:
+
+```bash
+FLINT_CASES=shellcheck/clean cargo test cases
+```
+
+If you have Flint checked out locally, prefer running it directly with Cargo:
+
+```bash
+cargo run -- run
+cargo run -- run --fix
+```
+
+## Testing an unreleased branch in a consumer repo
+
+If you do **not** have Flint checked out locally and want to test a branch in a
+consumer repo, pin a cargo git dependency in that repo's `mise.toml`:
+
+```toml
+[tools]
+"cargo:https://github.com/trask/flint" = { version = "branch:fix-lychee-windows-arg-limit", crate = "flint", bin = "flint" }
+```
+
+That `trask/flint` example is just a fork used for branch testing; use your own
+fork/branch as needed.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ For more commands and flags, see the [CLI reference](docs/cli.md).
 > [adaptive runs](docs/cli.md#adaptive-runs). When it happens, flint prints the
 > command to reproduce locally (usually `--full` or the linter name).
 
+For Flint contributor workflow and local testing tips, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Linters
 
 <!-- registry-table-start -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,20 @@ flint init -y --flint-rev <git-rev>
 That writes a cargo-backed Flint pin. To return to the released Flint backend
 after the release is cut, run `flint init` again without `--flint-rev`.
 
+If you want to test an unreleased Flint branch in a consumer repo without
+checking Flint out locally, you can also pin it directly in `mise.toml`, for
+example:
+
+```toml
+[tools]
+"cargo:https://github.com/trask/flint" = { version = "branch:fix-lychee-windows-arg-limit", crate = "flint", bin = "flint" }
+```
+
+That `trask/flint` example is just a fork used for branch testing; if you have
+Flint checked out locally, prefer `cargo run` / `cargo test` there instead.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the broader local development
+workflow.
+
 `flint init` is also the explicit way to reconcile a repo with the latest Flint
 setup defaults. Routine lint runs use `flint-setup` and only fail when an
 actionable setup migration applies to the repo.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,11 +197,12 @@ example:
 
 ```toml
 [tools]
-"cargo:https://github.com/trask/flint" = { version = "branch:fix-lychee-windows-arg-limit", crate = "flint", bin = "flint" }
+"cargo:https://github.com/grafana/flint" = "rev:<git-ref>"
 ```
 
-That `trask/flint` example is just a fork used for branch testing; if you have
-Flint checked out locally, prefer `cargo run` / `cargo test` there instead.
+Replace `<git-ref>` with the branch, tag, or commit you want to test. If you
+have Flint checked out locally, prefer `cargo run` / `cargo test` there
+instead.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the broader local development
 workflow.
 


### PR DESCRIPTION
## What changed
- add a contributor/local-testing section to the README
- document branch-based testing via a cargo git pin in `mise.toml`
- clarify when to prefer `cargo run` / `cargo test` for local Flint development

## Why
The repo already had scattered testing instructions, but it did not clearly document the common local contributor workflow or how to test an unreleased Flint branch from a consumer repo.

## Impact
Contributors have a clearer path for:
- local Flint development with Cargo
- targeted fixture runs
- testing a branch from another repo without checking Flint out locally

## Validation
- `cargo test`
- `mise run lint:fix`
