### PR TITLE
perf: batch rumdl file checks

### DIFF
--- a/.github/agents/knowledge/linters.md
+++ b/.github/agents/knowledge/linters.md
@@ -54,10 +54,10 @@ remains in effect.
 
 ```rust
 // Example: rumdl accepts --config <path>
-Check::file("rumdl", "rumdl check {FILE}", &["*.md"])
-    .fix("rumdl check --fix {FILE}")
+Check::files("rumdl", "rumdl check {FILES}", &["*.md"])
+    .fix("rumdl check --fix {FILES}")
     .linter_config(".rumdl.toml", "--config"),
-// → rumdl --config /repo/.github/config/.rumdl.toml check <file>
+// → rumdl --config /repo/.github/config/.rumdl.toml check <files...>
 ```
 
 **When NOT to use it:**

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -372,7 +372,7 @@ Format Python code
 | -------- | --------------------------------------------------------------------- |
 | Fix      | yes                                                                   |
 | Binary   | `rumdl`                                                               |
-| Scope    | [file](#scope-file)                                                   |
+| Scope    | [files](#scope-files)                                                 |
 | Patterns | `*.md`                                                                |
 | Config   | [`.rumdl.toml`](https://rumdl.dev/mdformat-comparison/#configuration) |
 

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -179,8 +179,8 @@ fn check_shfmt() -> Check {
 }
 
 fn check_rumdl() -> Check {
-    Check::file("rumdl", "rumdl check {FILE}", &["*.md"])
-        .fix("rumdl check --fix {FILE}")
+    Check::files("rumdl", "rumdl check {FILES}", &["*.md"])
+        .fix("rumdl check --fix {FILES}")
         .linter_config(".rumdl.toml", "--config")
         .baseline_config(ConfigFile::config_dir(".rumdl.toml"))
         .unsupported_configs(RUMDL_UNSUPPORTED_CONFIGS)

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -101,6 +101,24 @@ fn registry_tool_key_migrations_are_unique_and_have_targets() {
 }
 
 #[test]
+fn rumdl_batches_matching_files() {
+    let check = builtin()
+        .into_iter()
+        .find(|check| check.name == "rumdl")
+        .unwrap();
+
+    assert!(matches!(
+        check.kind,
+        CheckKind::Template {
+            check_cmd: "rumdl check {FILES}",
+            fix_cmd: "rumdl check --fix {FILES}",
+            scope: Scope::Files,
+            ..
+        }
+    ));
+}
+
+#[test]
 fn find_unsupported_key_detects_markdownlint_stack() {
     let mut tools = HashMap::new();
     tools.insert("npm:markdownlint-cli2".to_string(), "0.18.1".to_string());


### PR DESCRIPTION
Run rumdl once per command-line-sized file batch instead of once per Markdown file. This removes repeated process startup overhead, especially on Windows, while preserving existing changed-file selection and command-length chunking. Update the generated linter reference and add registry coverage for the batched check and fix templates.