### PR TITLE
feat: add native Java formatting and regex replacements

### DIFF
--- a/docs/linters/google-java-format.md
+++ b/docs/linters/google-java-format.md
@@ -8,17 +8,58 @@
 | Project  | [google-java-format](https://github.com/google/google-java-format) |
 | Fix      | yes                                                                |
 | Binary   | `google-java-format`                                               |
-| Scope    | [files](../linters.md#scope-files)                                 |
+| Scope    | [native](../linters.md#scope-native)                               |
 | Patterns | `*.java`                                                           |
 
 <!-- linter-metadata-end -->
 
-`google-java-format` checks and formats Java code. Flint uses its dry-run mode
-on changed files; apply the formatter with:
+`google-java-format` checks and formats Java code. Flint can limit ownership to
+configured paths and preserve regions delimited by repository-specific
+formatter-off markers.
 
-```bash
-flint run --fix google-java-format
+Configure google-java-format options and file ownership in `flint.toml`:
+
+```toml
+[checks.google-java-format]
+patterns = ["src/**/*.java"]
+exclude = ["src/generated/**"]
+skip_reflowing_long_strings = true
+skip_sorting_imports = false
+skip_removing_unused_imports = false
+skip_javadoc_formatting = false
+aosp = false
 ```
 
-Flint also disables EditorConfig line-length enforcement for Java files so
-google-java-format remains the formatting authority.
+`patterns` defaults to `["*.java"]`. Both `patterns` and `exclude` use the same
+glob syntax as `[settings].exclude`.
+
+`skip_reflowing_long_strings` defaults to `true` in Flint to match the
+established Spotless behavior. Set it to `false` to use google-java-format's
+upstream default. The other google-java-format options default to `false`.
+
+## Preserving formatter-off regions
+
+For formatter-off directives that google-java-format does not understand,
+configure one or more marker pairs:
+
+```toml
+[checks.google-java-format]
+off_on_markers = [
+  { off = "// spotless:off", on = "// spotless:on" },
+]
+```
+
+Flint formats a temporary copy of a marked file, restores the protected
+regions, and then compares or writes the result. Marker lines and everything
+between them remain unchanged.
+
+Each marker pair must be balanced. Flint reports a configuration error when it
+finds an `on` marker without a preceding `off` marker or an `off` marker without
+a following `on` marker.
+
+Run the check explicitly while setting it up:
+
+```bash
+flint run --full google-java-format
+flint run --full --fix google-java-format
+```

--- a/docs/linters/license-header.md
+++ b/docs/linters/license-header.md
@@ -18,12 +18,14 @@ text near the top. It is disabled by default; configure it in `flint.toml`:
 ```toml
 [checks.license-header]
 text = "SPDX-License-Identifier: Apache-2.0"
-patterns = ["*.java", "*.kt"]
+patterns = ["*.java", "*.kt", "*.scala", "*.groovy"]
+exclude = ["package-info.java"]
 lines_to_check = 5
 ```
 
 - `text` — required header text to find near the top of each file
 - `patterns` — glob patterns selecting which files to check
+- `exclude` — glob patterns excluded after `patterns`
 - `lines_to_check` — how many leading lines to search; defaults to `5`
 
 `text` may be multi-line. Flint joins the first `lines_to_check` lines with

--- a/docs/linters/regex-replace.md
+++ b/docs/linters/regex-replace.md
@@ -1,0 +1,193 @@
+# `regex-replace`
+
+<!-- linter-metadata-start -->
+<!-- Generated. Run `mise run generate` to regenerate. -->
+
+|        |                                            |
+| ------ | ------------------------------------------ |
+| Fix    | yes                                        |
+| Binary | (built-in)                                 |
+| Scope  | [native](../linters.md#scope-native)       |
+| Config | via `[checks.regex-replace]` in flint.toml |
+
+<!-- linter-metadata-end -->
+
+`regex-replace` is Flint's built-in, line-oriented rewrite engine. It applies
+regular-expression rules to selected files and can add text when a rule
+matches. It does not parse a programming language or contain Java-specific
+logic; the language convention is expressed by the configured regular
+expressions.
+
+This makes it useful for repository-specific mechanical changes that do not
+belong in a general-purpose formatter.
+
+## Example: qualified Java references to static imports
+
+One example is replacing frequently used qualified Java references with static
+imports. Given:
+
+```java
+import java.util.Objects;
+
+class Example {
+  void check(Object value) {
+    Objects.requireNonNull(value);
+  }
+}
+```
+
+the desired result is:
+
+```java
+import static java.util.Objects.requireNonNull;
+import java.util.Objects;
+
+class Example {
+  void check(Object value) {
+    requireNonNull(value);
+  }
+}
+```
+
+The rule has two effects:
+
+1. It rewrites `Objects.requireNonNull` to `requireNonNull`.
+2. It adds the corresponding import once, before the first import or after
+   the package declaration when the file has no imports.
+
+Here is a realistic configuration based on the static-import migration this
+check was designed to support:
+
+```toml
+[checks.regex-replace]
+patterns = ["*.java"]
+exclude = ["generated/**", "build/**"]
+
+[[checks.regex-replace.sets]]
+name = "static-imports"
+
+# Rules inherit this replacement unless they specify one themselves.
+# $1 is the first capture group in each direct rule.
+replacement = '$1'
+skip_line_pattern = '^\s*import '
+add_lines_before_pattern = '^\s*import '
+add_lines_fallback_after_pattern = '^\s*package '
+
+# Do not rewrite examples or references inside block comments.
+ignore_regions = [
+  { start_pattern = '^\s*/\*', end_pattern = '\*/' },
+]
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bObjects\.(requireNonNull)\b'
+add_lines = ['import static java.util.Objects.$1;']
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bElementMatchers\.([a-z][a-zA-Z0-9]*)\b'
+add_lines = ['import static net.bytebuddy.matcher.ElementMatchers.$1;']
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bMockito\.(mock|mockStatic|spy|when|verify|never|times)\b'
+add_lines = ['import static org.mockito.Mockito.$1;']
+
+[[checks.regex-replace.sets.rules]]
+pattern = '(^|[^.])\bLevel\.([A-Z][A-Z_0-9]*)\b'
+replacement = '$1$2'
+add_lines = ['import static java.util.logging.Level.$2;']
+content_pattern = '(?m)^\s*import java\.util\.logging\.Level;$'
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bAttributeKey\.(stringKey|longKey|booleanKey|doubleKey)\b'
+add_lines = ['import static io.opentelemetry.api.common.AttributeKey.$1;']
+line_exclude_pattern = '= AttributeKey\.'
+file_pattern = 'Test\.java$'
+
+# Generate rules from existing imports. For example, an import of
+# io.opentelemetry.semconv.http.HttpAttributes lets the same rule rewrite
+# HttpAttributes.HTTP_REQUEST_METHOD and add the matching static import.
+[[checks.regex-replace.sets.derived_rules]]
+source_pattern = '^import (?P<package>io\.opentelemetry\.semconv(?:\.[a-z][a-z.]*)?\.)(?P<class>[A-Z][a-zA-Z0-9]+);$'
+pattern = '\b{class}\.([A-Z][A-Z_0-9]*)\b'
+add_lines = ['import static {package}$1;']
+source_exclude_pattern = 'SchemaUrls'
+```
+
+Run it like any other fixable Flint check:
+
+```bash
+flint run regex-replace
+flint run --fix regex-replace
+```
+
+## How the configuration is organized
+
+### File selection
+
+The check-level `patterns` and `exclude` select the files Flint gives to the
+linter. Each rule set can add its own `patterns` and `exclude`, using the same
+glob syntax as `[settings].exclude`:
+
+```toml
+[checks.regex-replace]
+patterns = ["*.java", "*.kt"]
+exclude = ["generated/**"]
+
+[[checks.regex-replace.sets]]
+name = "java-only"
+patterns = ["*.java"]
+exclude = ["examples/**"]
+```
+
+This lets one `regex-replace` check contain independent rule sets for
+different file types or directory scopes.
+
+### Rule sets and defaults
+
+Sets are evaluated in order. A set groups rules that share policy and defaults:
+
+- `replacement` is inherited by direct and derived rules.
+- A rule-level `replacement` overrides the set default.
+- If neither is configured, the replacement is `$0`, preserving the match.
+- `add_lines_before_pattern` and
+  `add_lines_fallback_after_pattern` control where unique added lines go.
+- `skip_line_pattern` skips entire lines for every rule in the set.
+- `ignore_regions` skips balanced regions for every rule in the set.
+
+Added lines are deduplicated against the file, so rerunning the fixer does not
+keep adding the same import.
+
+### Rule filters
+
+Direct rules support additional filters:
+
+- `content_pattern` — only apply when the whole file contains a match.
+- `content_exclude_pattern` — skip the rule when the whole file contains a
+  match.
+- `line_exclude_pattern` — skip a line when its nearby context matches.
+- `file_pattern` — restrict the rule using the file name.
+
+Derived rules use `source_pattern` to find source lines and named captures such
+as `{package}` and `{class}` to generate a rule. Their
+`source_exclude_pattern` prevents selected source lines from generating rules.
+Capture groups from the generated rule remain available as `$1`, `$2`, and so
+on in `replacement` and `add_lines`.
+
+### Ignored regions
+
+`ignore_regions` is line-based and generic. Each `start_pattern` and
+`end_pattern` is a regular expression matched against a complete source line;
+the marker lines and every line between them are skipped. The markers must be
+balanced. This is useful for block comments, generated snippets, or repository
+conventions that should not be rewritten.
+
+It is deliberately separate from formatter-specific formatter-off handling:
+`regex-replace` skips those lines, while a formatter integration may instead
+format a temporary copy and restore the protected contents afterward.
+
+## Limitations
+
+`regex-replace` is intentionally not a parser or import sorter. It cannot
+prove that a replacement is syntactically valid, resolve overloaded methods,
+or determine whether a static import conflicts with another symbol. Keep the
+patterns narrow, use content and file filters where needed, and review the
+result of a new rule with `flint run --fix` before enabling it broadly.

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,10 @@ pub struct ChecksConfig {
     pub renovate_deps: RenovateDepsConfig,
     #[serde(rename = "license-header", alias = "license_header")]
     pub license_header: LicenseHeaderConfig,
+    #[serde(rename = "google-java-format", alias = "google_java_format")]
+    pub google_java_format: GoogleJavaFormatConfig,
+    #[serde(rename = "regex-replace", alias = "regex_replace")]
+    pub regex_replace: RegexReplaceConfig,
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -66,6 +70,9 @@ pub struct LicenseHeaderConfig {
     pub text: String,
     /// Glob patterns for files to check (e.g. `["*.java", "*.kt"]`).
     pub patterns: Vec<String>,
+    /// Glob patterns excluded after `patterns` are matched. Uses the same glob
+    /// syntax as `settings.exclude`.
+    pub exclude: Vec<String>,
     /// How many lines from the top of each file to search. Default: 5.
     pub lines_to_check: usize,
 }
@@ -75,9 +82,145 @@ impl Default for LicenseHeaderConfig {
         Self {
             text: String::new(),
             patterns: vec![],
+            exclude: vec![],
             lines_to_check: 5,
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct GoogleJavaFormatConfig {
+    /// Restrict formatting to paths matching these globs. An empty list uses the
+    /// check's registered patterns.
+    pub patterns: Vec<String>,
+    /// Glob patterns excluded after `patterns` are matched. Uses the same glob
+    /// syntax as `settings.exclude`.
+    pub exclude: Vec<String>,
+    /// Keep the behavior used by Spotless and google-java-format 1.35, which
+    /// does not reflow long strings unless explicitly requested.
+    pub skip_reflowing_long_strings: bool,
+    pub skip_sorting_imports: bool,
+    pub skip_removing_unused_imports: bool,
+    pub skip_javadoc_formatting: bool,
+    pub aosp: bool,
+    /// Comment marker pairs whose regions should be restored after formatting.
+    /// This is useful for repositories using formatter-off directives that GJF
+    /// itself does not understand.
+    pub off_on_markers: Vec<OffOnMarkerConfig>,
+}
+
+impl Default for GoogleJavaFormatConfig {
+    fn default() -> Self {
+        Self {
+            patterns: vec![],
+            exclude: vec![],
+            skip_reflowing_long_strings: true,
+            skip_sorting_imports: false,
+            skip_removing_unused_imports: false,
+            skip_javadoc_formatting: false,
+            aosp: false,
+            off_on_markers: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct OffOnMarkerConfig {
+    pub off: String,
+    pub on: String,
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+#[serde(default)]
+pub struct RegexReplaceConfig {
+    /// Restrict rewriting to paths matching these globs. An empty list uses
+    /// all files in the Flint file list.
+    pub patterns: Vec<String>,
+    /// Glob patterns excluded after `patterns` are matched. Uses the same glob
+    /// syntax as `settings.exclude`.
+    pub exclude: Vec<String>,
+    /// Ordered rule sets. Each set has its own scope and defaults.
+    pub sets: Vec<RegexReplaceSetConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, Clone)]
+#[serde(default)]
+pub struct RegexReplaceSetConfig {
+    /// Human-readable name used in diagnostics and documentation.
+    pub name: String,
+    /// Additional file scope for this set. Empty means all files selected by
+    /// the parent check.
+    pub patterns: Vec<String>,
+    /// Additional exclusions for this set, using the same glob syntax as
+    /// `settings.exclude`.
+    pub exclude: Vec<String>,
+    /// Defaults inherited by rules in this set. A rule can override them.
+    pub replacement: Option<String>,
+    /// Optional line regexes controlling where this set's `add_lines` are
+    /// inserted.
+    pub add_lines_before_pattern: Option<String>,
+    pub add_lines_fallback_after_pattern: Option<String>,
+    /// Ignore source lines matching this regex before applying this set.
+    pub skip_line_pattern: Option<String>,
+    /// Configured regions to ignore while applying this set. This is generic
+    /// region handling; it does not assume a particular comment syntax.
+    pub ignore_regions: Vec<RegexReplaceIgnoreRegionConfig>,
+    pub rules: Vec<RegexReplaceRuleConfig>,
+    /// Rules that derive a replacement rule from a line matched by
+    /// `source_pattern`.
+    pub derived_rules: Vec<DerivedRegexReplaceRuleConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RegexReplaceIgnoreRegionConfig {
+    /// Regex matching the line where an ignored region starts.
+    pub start_pattern: String,
+    /// Regex matching the line where an ignored region ends.
+    pub end_pattern: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RegexReplaceRuleConfig {
+    /// Regex matching text to replace. Capture groups may be used by
+    /// `replacement` and `add_lines`.
+    pub pattern: String,
+    /// Replacement text passed to regex capture expansion. When omitted, the
+    /// set's replacement default is used, then `$0`.
+    #[serde(default)]
+    pub replacement: Option<String>,
+    /// Lines to add when this rule matches, also supporting regex capture
+    /// expansion.
+    #[serde(default)]
+    pub add_lines: Vec<String>,
+    /// Only apply this rule when the file contains a match for this regex.
+    #[serde(default)]
+    pub content_pattern: Option<String>,
+    #[serde(default)]
+    pub line_exclude_pattern: Option<String>,
+    #[serde(default)]
+    pub file_pattern: Option<String>,
+    #[serde(default)]
+    pub content_exclude_pattern: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct DerivedRegexReplaceRuleConfig {
+    /// Regex matched against source lines. Named captures can be referenced as
+    /// `{name}` in the other fields.
+    pub source_pattern: String,
+    /// Regex for replacement text. `{name}` placeholders are replaced with
+    /// escaped source captures before this regex is compiled.
+    pub pattern: String,
+    /// Overrides the set replacement default; otherwise `$0` is used.
+    #[serde(default)]
+    pub replacement: Option<String>,
+    /// Lines to add. `{name}` source placeholders and `$1`, `$2`, ... match
+    /// captures may be used.
+    #[serde(default)]
+    pub add_lines: Vec<String>,
+    #[serde(default)]
+    pub source_exclude_pattern: Option<String>,
 }
 
 /// Builds env-var prefix → figment key-path mappings for every check in the registry.

--- a/src/files.rs
+++ b/src/files.rs
@@ -59,14 +59,19 @@ pub fn changed(
 }
 
 fn build_exclude_set(cfg: &Config) -> GlobSet {
+    let patterns: Vec<&str> = cfg.settings.exclude.iter().map(String::as_str).collect();
+    build_glob_set(&patterns)
+}
+
+fn build_glob_set(patterns: &[&str]) -> GlobSet {
     let mut builder = GlobSetBuilder::new();
-    for pattern in &cfg.settings.exclude {
+    for pattern in patterns {
         match GlobBuilder::new(pattern).literal_separator(true).build() {
             Ok(glob) => {
                 builder.add(glob);
             }
-            Err(e) => {
-                eprintln!("flint: invalid exclude pattern {pattern:?}: {e}");
+            Err(error) => {
+                eprintln!("flint: invalid glob pattern {pattern:?}: {error}");
             }
         }
     }
@@ -258,6 +263,8 @@ pub fn match_files<'a>(
     exclude_patterns: &[&str],
     project_root: &Path,
 ) -> Vec<&'a PathBuf> {
+    let patterns = build_glob_set(patterns);
+    let exclude_patterns = build_glob_set(exclude_patterns);
     files
         .iter()
         .filter(|p| {
@@ -267,40 +274,13 @@ pub fn match_files<'a>(
                 .file_name()
                 .map(|n| n.to_string_lossy())
                 .unwrap_or_default();
-            let included = patterns.iter().any(|pat| {
-                if *pat == "*" {
-                    return true;
-                }
-                glob_match(pat, file_name.as_ref()) || glob_match(pat, rel_str.as_ref())
-            });
-            let excluded = exclude_patterns.iter().any(|pat| {
-                glob_match(pat, file_name.as_ref()) || glob_match(pat, rel_str.as_ref())
-            });
+            let included =
+                patterns.is_match(file_name.as_ref()) || patterns.is_match(rel_str.as_ref());
+            let excluded = exclude_patterns.is_match(file_name.as_ref())
+                || exclude_patterns.is_match(rel_str.as_ref());
             included && !excluded
         })
         .collect()
-}
-
-fn glob_match(pattern: &str, name: &str) -> bool {
-    // Simple glob: splits on `*` and checks that each segment appears in order.
-    // Handles `*.ext`, `prefix*`, `dir/*.yml`, etc.
-    let parts: Vec<&str> = pattern.splitn(2, '*').collect();
-    match parts.as_slice() {
-        [only] => name == *only || name.ends_with(&format!("/{only}")),
-        [prefix, suffix] => {
-            let n = name;
-            // The prefix must match the start of the name (or the part after the last slash).
-            let anchor_start = prefix.is_empty() || n.starts_with(prefix) || {
-                // Allow matching the basename portion for patterns like `*.sh`.
-                n.contains('/') && {
-                    let after_slash = n.rfind('/').map(|i| &n[i + 1..]).unwrap_or(n);
-                    prefix.is_empty() || after_slash.starts_with(prefix)
-                }
-            };
-            anchor_start && n.ends_with(suffix)
-        }
-        _ => false,
-    }
 }
 
 #[cfg(test)]
@@ -401,6 +381,19 @@ mod tests {
             filter_names(tmp.path(), &GlobSetBuilder::new().build().unwrap(), names).unwrap();
 
         assert_eq!(files, vec![tmp.path().join("tracked.sh")]);
+    }
+
+    #[test]
+    fn match_files_uses_settings_glob_syntax_for_check_excludes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = vec![
+            tmp.path().join("src/kept/Foo.java"),
+            tmp.path().join("src/excluded/nested/Bar.java"),
+        ];
+
+        let matched = match_files(&files, &["*.java"], &["src/excluded/**"], tmp.path());
+
+        assert_eq!(matched, vec![&files[0]]);
     }
 
     /// Regression test for os error 206 (ERROR_FILENAME_EXCED_RANGE) on Windows: the previous

--- a/src/linters/google_java_format.rs
+++ b/src/linters/google_java_format.rs
@@ -1,0 +1,387 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use crate::config::{GoogleJavaFormatConfig, OffOnMarkerConfig};
+use crate::files::match_files;
+use crate::linters::{LinterOutput, spawn_command};
+use crate::regions::{RegionError, RegionSpan, find_region_spans};
+use crate::registry::{
+    CheckTypeDef, NativeCheckDef, NativePrepareContext, NativeRunContext, NativeRunFuture,
+    PreparedNativeCheck,
+};
+
+pub(crate) static CHECK_TYPE: CheckTypeDef = CheckTypeDef::native(
+    "google-java-format",
+    NativeCheckDef::with_bin("google-java-format", prepare).with_fix(),
+);
+
+#[derive(Debug)]
+struct PreparedGoogleJavaFormat {
+    name: String,
+    cfg: GoogleJavaFormatConfig,
+    files: Vec<PathBuf>,
+}
+
+fn prepare(ctx: NativePrepareContext<'_>) -> Option<Box<dyn PreparedNativeCheck>> {
+    let configured_patterns: Vec<&str> = ctx
+        .cfg
+        .checks
+        .google_java_format
+        .patterns
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let patterns = if configured_patterns.is_empty() {
+        vec!["*.java"]
+    } else {
+        configured_patterns
+    };
+    let excludes: Vec<&str> = ctx
+        .cfg
+        .checks
+        .google_java_format
+        .exclude
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let files: Vec<PathBuf> =
+        match_files(&ctx.file_list.files, &patterns, &excludes, ctx.project_root)
+            .into_iter()
+            .cloned()
+            .collect();
+
+    if files.is_empty() {
+        return None;
+    }
+
+    Some(Box::new(PreparedGoogleJavaFormat {
+        name: ctx.name.to_string(),
+        cfg: ctx.cfg.checks.google_java_format.clone(),
+        files,
+    }))
+}
+
+impl PreparedNativeCheck for PreparedGoogleJavaFormat {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn tracked_files(&self) -> &[PathBuf] {
+        &self.files
+    }
+
+    fn run(self: Box<Self>, ctx: NativeRunContext) -> NativeRunFuture {
+        Box::pin(async move { run(&self.cfg, &ctx.project_root, &self.files, ctx.fix).await })
+    }
+}
+
+pub(crate) async fn run(
+    cfg: &GoogleJavaFormatConfig,
+    project_root: &Path,
+    files: &[PathBuf],
+    fix: bool,
+) -> LinterOutput {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut all_ok = true;
+    let mut batch = Vec::new();
+
+    for file in files {
+        if has_configured_marker(file, &cfg.off_on_markers) {
+            if let Err(error) =
+                run_marked_file(cfg, project_root, file, fix, &mut stdout, &mut stderr).await
+            {
+                all_ok = false;
+                if error.to_string() != "formatting changes required" {
+                    append_error(&mut stderr, project_root, file, &error);
+                }
+            }
+        } else {
+            batch.push(file);
+        }
+    }
+
+    for chunk in chunks(&batch) {
+        match run_batch(cfg, project_root, chunk, fix).await {
+            Ok(output) => {
+                if !output.status.success() {
+                    all_ok = false;
+                }
+                stdout.extend_from_slice(&output.stdout);
+                stderr.extend_from_slice(&output.stderr);
+            }
+            Err(error) => {
+                all_ok = false;
+                stderr
+                    .extend_from_slice(format!("flint: google-java-format: {error}\n").as_bytes());
+            }
+        }
+    }
+
+    LinterOutput {
+        ok: all_ok,
+        stdout,
+        stderr,
+        setup_outcome: None,
+    }
+}
+
+fn build_args(cfg: &GoogleJavaFormatConfig, fix: bool) -> Vec<String> {
+    let mut args = vec!["google-java-format".to_string()];
+    if cfg.aosp {
+        args.push("--aosp".to_string());
+    }
+    if cfg.skip_reflowing_long_strings {
+        args.push("--skip-reflowing-long-strings".to_string());
+    }
+    if cfg.skip_sorting_imports {
+        args.push("--skip-sorting-imports".to_string());
+    }
+    if cfg.skip_removing_unused_imports {
+        args.push("--skip-removing-unused-imports".to_string());
+    }
+    if cfg.skip_javadoc_formatting {
+        args.push("--skip-javadoc-formatting".to_string());
+    }
+    if fix {
+        args.push("-i".to_string());
+    } else {
+        args.extend(["--dry-run".to_string(), "--set-exit-if-changed".to_string()]);
+    }
+    args
+}
+
+async fn run_batch(
+    cfg: &GoogleJavaFormatConfig,
+    project_root: &Path,
+    files: &[&PathBuf],
+    fix: bool,
+) -> std::io::Result<std::process::Output> {
+    let mut args = build_args(cfg, fix);
+    args.extend(files.iter().map(|file| file.to_string_lossy().into_owned()));
+    spawn_command(&args, false)
+        .current_dir(project_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+}
+
+async fn run_marked_file(
+    cfg: &GoogleJavaFormatConfig,
+    project_root: &Path,
+    file: &Path,
+    fix: bool,
+    stdout: &mut Vec<u8>,
+    stderr: &mut Vec<u8>,
+) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(file)?;
+    let tempdir = tempfile::tempdir()?;
+    let temp_file = tempdir.path().join(
+        file.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("source.java"),
+    );
+    std::fs::write(&temp_file, &original)?;
+
+    let mut args = build_args(cfg, true);
+    args.push(temp_file.to_string_lossy().into_owned());
+    let output = spawn_command(&args, false)
+        .current_dir(project_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+    stdout.extend_from_slice(&output.stdout);
+    stderr.extend_from_slice(&output.stderr);
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "google-java-format exited with status {}",
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+
+    let formatted = std::fs::read_to_string(&temp_file)?;
+    let restored = restore_marked_regions(&original, &formatted, &cfg.off_on_markers)
+        .map_err(std::io::Error::other)?;
+    if restored == original {
+        return Ok(());
+    }
+    if fix {
+        std::fs::write(file, restored)?;
+    } else {
+        let rel = file.strip_prefix(project_root).unwrap_or(file);
+        stderr.extend_from_slice(format!("{}\n", rel.to_string_lossy()).as_bytes());
+        return Err(std::io::Error::other("formatting changes required"));
+    }
+    Ok(())
+}
+
+fn has_configured_marker(file: &Path, markers: &[OffOnMarkerConfig]) -> bool {
+    if markers.is_empty() {
+        return false;
+    }
+    let Ok(content) = std::fs::read_to_string(file) else {
+        return false;
+    };
+    markers.iter().any(|marker| content.contains(&marker.off))
+}
+
+fn restore_marked_regions(
+    original: &str,
+    formatted: &str,
+    markers: &[OffOnMarkerConfig],
+) -> Result<String, String> {
+    let original_lines: Vec<&str> = original.lines().collect();
+    let mut formatted_lines: Vec<String> = formatted.lines().map(ToString::to_string).collect();
+
+    let original_regions = find_marker_spans(&original_lines, markers)?;
+    let mut formatted_regions = find_marker_spans(
+        &formatted_lines
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        markers,
+    )?;
+    if original_regions.len() != formatted_regions.len() {
+        return Err(format!(
+            "formatter-off markers changed from {} regions to {}",
+            original_regions.len(),
+            formatted_regions.len()
+        ));
+    }
+
+    let mut original_regions = original_regions;
+    original_regions.sort_by_key(|region| (region.marker_index, region.start_line));
+    formatted_regions.sort_by_key(|region| (region.marker_index, region.start_line));
+    for (original_region, formatted_region) in original_regions.iter().zip(&formatted_regions) {
+        if original_region.marker_index != formatted_region.marker_index {
+            return Err("formatter-off marker pairs changed order".to_string());
+        }
+    }
+
+    // Replace from the bottom up so earlier line indexes remain valid after
+    // restoring a region whose contents have a different number of lines.
+    let mut replacements: Vec<_> = original_regions.iter().zip(&formatted_regions).collect();
+    replacements.sort_by_key(|(_, formatted)| std::cmp::Reverse(formatted.start_line));
+    for (original_region, formatted_region) in replacements {
+        formatted_lines.splice(
+            formatted_region.start_line + 1..formatted_region.end_line,
+            original_lines[original_region.start_line + 1..original_region.end_line]
+                .iter()
+                .map(|line| (*line).to_string()),
+        );
+    }
+
+    let mut output = formatted_lines.join("\n");
+    if formatted.ends_with('\n') {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn find_marker_spans(
+    lines: &[&str],
+    markers: &[OffOnMarkerConfig],
+) -> Result<Vec<RegionSpan>, String> {
+    find_region_spans(
+        lines,
+        markers,
+        |marker, line| line.contains(&marker.off),
+        |marker, line| line.contains(&marker.on),
+    )
+    .map_err(|error| format_marker_error(error, markers))
+}
+
+fn format_marker_error(error: RegionError, markers: &[OffOnMarkerConfig]) -> String {
+    match error {
+        RegionError::EndWithoutStart { marker_index, .. } => {
+            let marker = &markers[marker_index];
+            format!(
+                "formatter-on marker {:?} has no matching formatter-off marker {:?}",
+                marker.on, marker.off
+            )
+        }
+        RegionError::StartWithoutEnd { marker_index, .. } => {
+            let marker = &markers[marker_index];
+            format!(
+                "formatter-off marker {:?} has no matching {:?}",
+                marker.off, marker.on
+            )
+        }
+    }
+}
+
+fn chunks<'a>(files: &'a [&'a PathBuf]) -> Vec<&'a [&'a PathBuf]> {
+    // Keep command lines comfortably below Windows' limit. GJF is invoked in
+    // a native check so it does not pass through runner.rs's template chunker.
+    const MAX_CHARS: usize = 6_000;
+    let mut result = Vec::new();
+    let mut start = 0;
+    let mut length = 0;
+    for (index, file) in files.iter().enumerate() {
+        let file_length = file.to_string_lossy().len() + 1;
+        if index > start && length + file_length > MAX_CHARS {
+            result.push(&files[start..index]);
+            start = index;
+            length = 0;
+        }
+        length += file_length;
+    }
+    if start < files.len() {
+        result.push(&files[start..]);
+    }
+    result
+}
+
+fn append_error(stderr: &mut Vec<u8>, project_root: &Path, file: &Path, error: &std::io::Error) {
+    let rel = file.strip_prefix(project_root).unwrap_or(file);
+    stderr.extend_from_slice(format!("{}: {error}\n", rel.to_string_lossy()).as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restores_regions_between_markers() {
+        let marker = OffOnMarkerConfig {
+            off: "// spotless:off".to_string(),
+            on: "// spotless:on".to_string(),
+        };
+        let original = "class Test {\n// spotless:off\n  int a=  1;\n// spotless:on\n}\n";
+        let formatted = "class Test {\n  // spotless:off\n  int a = 1;\n  // spotless:on\n}\n";
+        let restored = restore_marked_regions(original, formatted, &[marker]).unwrap();
+        assert_eq!(
+            restored,
+            "class Test {\n  // spotless:off\n  int a=  1;\n  // spotless:on\n}\n"
+        );
+    }
+
+    #[test]
+    fn builds_configured_gjf_flags() {
+        let cfg = GoogleJavaFormatConfig {
+            aosp: true,
+            skip_reflowing_long_strings: true,
+            skip_sorting_imports: true,
+            skip_removing_unused_imports: true,
+            skip_javadoc_formatting: true,
+            ..GoogleJavaFormatConfig::default()
+        };
+        assert_eq!(
+            build_args(&cfg, false),
+            vec![
+                "google-java-format",
+                "--aosp",
+                "--skip-reflowing-long-strings",
+                "--skip-sorting-imports",
+                "--skip-removing-unused-imports",
+                "--skip-javadoc-formatting",
+                "--dry-run",
+                "--set-exit-if-changed",
+            ]
+        );
+    }
+}

--- a/src/linters/license_header.rs
+++ b/src/linters/license_header.rs
@@ -33,10 +33,19 @@ fn prepare(ctx: NativePrepareContext<'_>) -> Option<Box<dyn PreparedNativeCheck>
         .iter()
         .map(String::as_str)
         .collect();
-    let files: Vec<PathBuf> = match_files(&ctx.file_list.files, &patterns, &[], ctx.project_root)
-        .into_iter()
-        .cloned()
+    let excludes: Vec<&str> = ctx
+        .cfg
+        .checks
+        .license_header
+        .exclude
+        .iter()
+        .map(String::as_str)
         .collect();
+    let files: Vec<PathBuf> =
+        match_files(&ctx.file_list.files, &patterns, &excludes, ctx.project_root)
+            .into_iter()
+            .cloned()
+            .collect();
     if files.is_empty() {
         return None;
     }

--- a/src/linters/mod.rs
+++ b/src/linters/mod.rs
@@ -1,8 +1,10 @@
 pub mod biome;
 pub mod env;
 pub mod flint_setup;
+pub mod google_java_format;
 pub mod license_header;
 pub mod lychee;
+pub mod regex_replace;
 pub mod renovate_deps;
 pub mod rumdl;
 pub mod rustfmt;

--- a/src/linters/regex_replace.rs
+++ b/src/linters/regex_replace.rs
@@ -1,0 +1,720 @@
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use regex::{Captures, Regex};
+
+#[cfg(test)]
+use crate::config::{DerivedRegexReplaceRuleConfig, RegexReplaceIgnoreRegionConfig};
+use crate::config::{RegexReplaceConfig, RegexReplaceRuleConfig, RegexReplaceSetConfig};
+use crate::files::match_files;
+use crate::linters::LinterOutput;
+use crate::regions::{RegionSpan, find_region_spans};
+use crate::registry::{
+    CheckTypeDef, NativeCheckDef, NativePrepareContext, NativeRunContext, NativeRunFuture,
+    PreparedNativeCheck, StatusContext,
+};
+
+pub(crate) static CHECK_TYPE: CheckTypeDef = CheckTypeDef::native(
+    "regex-replace",
+    NativeCheckDef::new(prepare)
+        .with_fix()
+        .with_config_display("via `[checks.regex-replace]` in flint.toml"),
+);
+
+#[derive(Debug)]
+struct PreparedRegexReplace {
+    name: String,
+    cfg: RegexReplaceConfig,
+    files: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+struct CompiledConfig {
+    sets: Vec<CompiledSet>,
+}
+
+#[derive(Debug)]
+struct CompiledSet {
+    name: String,
+    patterns: Vec<String>,
+    exclude: Vec<String>,
+    replacement: Option<String>,
+    rules: Vec<CompiledRule>,
+    derived_rules: Vec<CompiledDerivedRule>,
+    add_lines_before_pattern: Option<Regex>,
+    add_lines_fallback_after_pattern: Option<Regex>,
+    skip_line_pattern: Option<Regex>,
+    ignore_regions: Vec<CompiledIgnoreRegion>,
+}
+
+#[derive(Debug)]
+struct CompiledIgnoreRegion {
+    start_pattern: Regex,
+    end_pattern: Regex,
+}
+
+#[derive(Debug)]
+struct CompiledRule {
+    pattern: Regex,
+    replacement: Option<String>,
+    add_lines: Vec<String>,
+    content_pattern: Option<Regex>,
+    content_exclude_pattern: Option<Regex>,
+    line_exclude_pattern: Option<Regex>,
+    file_pattern: Option<Regex>,
+}
+
+#[derive(Debug)]
+struct CompiledDerivedRule {
+    source_pattern: Regex,
+    pattern: String,
+    replacement: Option<String>,
+    add_lines: Vec<String>,
+    source_exclude_pattern: Option<Regex>,
+}
+
+struct RewriteOptions<'a> {
+    line_exclude: Option<&'a Regex>,
+    skip_line: Option<&'a Regex>,
+    ignore_regions: &'a [RegionSpan],
+}
+
+fn compile_config(cfg: &RegexReplaceConfig) -> Result<CompiledConfig, String> {
+    let sets = cfg
+        .sets
+        .iter()
+        .map(compile_set)
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(CompiledConfig { sets })
+}
+
+fn compile_set(set: &RegexReplaceSetConfig) -> Result<CompiledSet, String> {
+    let rules = set
+        .rules
+        .iter()
+        .map(compile_rule)
+        .collect::<Result<Vec<_>, String>>()?;
+    let derived_rules = set
+        .derived_rules
+        .iter()
+        .map(|rule| {
+            Ok(CompiledDerivedRule {
+                source_pattern: Regex::new(&rule.source_pattern).map_err(|error| {
+                    format!("invalid source_pattern {:?}: {error}", rule.source_pattern)
+                })?,
+                pattern: rule.pattern.clone(),
+                replacement: rule.replacement.clone(),
+                add_lines: rule.add_lines.clone(),
+                source_exclude_pattern: compile_optional(
+                    rule.source_exclude_pattern.as_deref(),
+                    "source_exclude_pattern",
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let ignore_regions = set
+        .ignore_regions
+        .iter()
+        .map(|region| {
+            Ok(CompiledIgnoreRegion {
+                start_pattern: Regex::new(&region.start_pattern).map_err(|error| {
+                    format!(
+                        "invalid ignore region start_pattern {:?}: {error}",
+                        region.start_pattern
+                    )
+                })?,
+                end_pattern: Regex::new(&region.end_pattern).map_err(|error| {
+                    format!(
+                        "invalid ignore region end_pattern {:?}: {error}",
+                        region.end_pattern
+                    )
+                })?,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(CompiledSet {
+        name: set.name.clone(),
+        patterns: set.patterns.clone(),
+        exclude: set.exclude.clone(),
+        replacement: set.replacement.clone(),
+        rules,
+        derived_rules,
+        add_lines_before_pattern: compile_optional(
+            set.add_lines_before_pattern.as_deref(),
+            "add_lines_before_pattern",
+        )?,
+        add_lines_fallback_after_pattern: compile_optional(
+            set.add_lines_fallback_after_pattern.as_deref(),
+            "add_lines_fallback_after_pattern",
+        )?,
+        skip_line_pattern: compile_optional(set.skip_line_pattern.as_deref(), "skip_line_pattern")?,
+        ignore_regions,
+    })
+}
+
+fn compile_rule(rule: &RegexReplaceRuleConfig) -> Result<CompiledRule, String> {
+    Ok(CompiledRule {
+        pattern: Regex::new(&rule.pattern).map_err(|error| {
+            format!("invalid regex-replace pattern {:?}: {error}", rule.pattern)
+        })?,
+        replacement: rule.replacement.clone(),
+        add_lines: rule.add_lines.clone(),
+        content_pattern: compile_optional(rule.content_pattern.as_deref(), "content_pattern")?,
+        content_exclude_pattern: compile_optional(
+            rule.content_exclude_pattern.as_deref(),
+            "content_exclude_pattern",
+        )?,
+        line_exclude_pattern: compile_optional(
+            rule.line_exclude_pattern.as_deref(),
+            "line_exclude_pattern",
+        )?,
+        file_pattern: compile_optional(rule.file_pattern.as_deref(), "file_pattern")?,
+    })
+}
+
+fn compile_optional(pattern: Option<&str>, name: &str) -> Result<Option<Regex>, String> {
+    pattern
+        .map(|pattern| Regex::new(pattern).map_err(|error| format!("invalid {name}: {error}")))
+        .transpose()
+}
+
+fn prepare(ctx: NativePrepareContext<'_>) -> Option<Box<dyn PreparedNativeCheck>> {
+    let cfg = &ctx.cfg.checks.regex_replace;
+    if !is_configured(cfg) {
+        return None;
+    }
+
+    let configured_patterns: Vec<&str> = cfg.patterns.iter().map(String::as_str).collect();
+    let patterns = if configured_patterns.is_empty() {
+        vec!["*"]
+    } else {
+        configured_patterns
+    };
+    let excludes: Vec<&str> = cfg.exclude.iter().map(String::as_str).collect();
+    let files: Vec<PathBuf> =
+        match_files(&ctx.file_list.files, &patterns, &excludes, ctx.project_root)
+            .into_iter()
+            .cloned()
+            .collect();
+
+    if files.is_empty() {
+        return None;
+    }
+
+    Some(Box::new(PreparedRegexReplace {
+        name: ctx.name.to_string(),
+        cfg: cfg.clone(),
+        files,
+    }))
+}
+
+impl PreparedNativeCheck for PreparedRegexReplace {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn tracked_files(&self) -> &[PathBuf] {
+        &self.files
+    }
+
+    fn run(self: Box<Self>, ctx: NativeRunContext) -> NativeRunFuture {
+        Box::pin(async move { run(&self.cfg, &ctx.project_root, &self.files, ctx.fix).await })
+    }
+}
+
+pub(crate) fn status(ctx: &dyn StatusContext) -> Option<&'static str> {
+    let cfg = &ctx.config().checks.regex_replace;
+    (!is_configured(cfg)).then_some("not configured")
+}
+
+fn is_configured(cfg: &RegexReplaceConfig) -> bool {
+    cfg.sets
+        .iter()
+        .any(|set| !set.rules.is_empty() || !set.derived_rules.is_empty())
+}
+
+pub(crate) async fn run(
+    cfg: &RegexReplaceConfig,
+    project_root: &Path,
+    files: &[PathBuf],
+    fix: bool,
+) -> LinterOutput {
+    let mut stderr = Vec::new();
+    let mut all_ok = true;
+    let compiled = match compile_config(cfg) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            return LinterOutput::err(format!("regex-replace: {error}\n"));
+        }
+    };
+
+    for file in files {
+        let rel = file.strip_prefix(project_root).unwrap_or(file);
+        let rel = rel.to_string_lossy();
+        let input = match std::fs::read_to_string(file) {
+            Ok(input) => input,
+            Err(error) => {
+                all_ok = false;
+                stderr.extend_from_slice(
+                    format!("{rel}: failed to read regex-replace input: {error}\n").as_bytes(),
+                );
+                continue;
+            }
+        };
+
+        let output = match rewrite_compiled(&input, file, project_root, &compiled) {
+            Ok(output) => output,
+            Err(error) => {
+                all_ok = false;
+                stderr.extend_from_slice(format!("{rel}: {error}\n").as_bytes());
+                continue;
+            }
+        };
+
+        if output == input {
+            continue;
+        }
+
+        if fix {
+            if let Err(error) = std::fs::write(file, output) {
+                all_ok = false;
+                stderr.extend_from_slice(
+                    format!("{rel}: failed to write regex-replace fix: {error}\n").as_bytes(),
+                );
+            }
+        } else {
+            all_ok = false;
+            stderr.extend_from_slice(
+                format!("{rel}: regex replacements are not formatted\n").as_bytes(),
+            );
+        }
+    }
+
+    LinterOutput {
+        ok: all_ok,
+        stdout: vec![],
+        stderr,
+        setup_outcome: None,
+    }
+}
+
+#[cfg(test)]
+fn rewrite(input: &str, file: &Path, cfg: &RegexReplaceConfig) -> Result<String, String> {
+    let compiled = compile_config(cfg)?;
+    rewrite_compiled(input, file, Path::new("."), &compiled)
+}
+
+fn rewrite_compiled(
+    input: &str,
+    file: &Path,
+    project_root: &Path,
+    cfg: &CompiledConfig,
+) -> Result<String, String> {
+    let mut content = input.to_string();
+
+    for set in &cfg.sets {
+        if !set_matches_file(set, file, project_root) {
+            continue;
+        }
+        rewrite_set(&mut content, file, set)
+            .map_err(|error| format!("rule set {:?}: {error}", set.name))?;
+    }
+
+    Ok(content)
+}
+
+fn set_matches_file(set: &CompiledSet, file: &Path, project_root: &Path) -> bool {
+    if set.patterns.is_empty() && set.exclude.is_empty() {
+        return true;
+    }
+    let configured_patterns: Vec<&str> = set.patterns.iter().map(String::as_str).collect();
+    let patterns = if configured_patterns.is_empty() {
+        vec!["*"]
+    } else {
+        configured_patterns
+    };
+    let excludes: Vec<&str> = set.exclude.iter().map(String::as_str).collect();
+    !match_files(
+        std::slice::from_ref(&file.to_path_buf()),
+        &patterns,
+        &excludes,
+        project_root,
+    )
+    .is_empty()
+}
+
+fn rewrite_set(content: &mut String, file: &Path, set: &CompiledSet) -> Result<(), String> {
+    let mut lines_to_add = BTreeSet::new();
+    let lines: Vec<&str> = content.lines().collect();
+    let ignored_regions = find_region_spans(
+        &lines,
+        &set.ignore_regions,
+        |region, line| region.start_pattern.is_match(line),
+        |region, line| region.end_pattern.is_match(line),
+    )
+    .map_err(|error| format!("invalid ignored region: {error}"))?;
+
+    for rule in &set.rules {
+        apply_rule(
+            content,
+            file,
+            rule,
+            set,
+            &ignored_regions,
+            &mut lines_to_add,
+        );
+    }
+    for rule in &set.derived_rules {
+        apply_derived_rule(content, rule, set, &ignored_regions, &mut lines_to_add)?;
+    }
+
+    *content = insert_lines(content, lines_to_add, set)?;
+    Ok(())
+}
+
+fn apply_rule(
+    content: &mut String,
+    file: &Path,
+    rule: &CompiledRule,
+    set: &CompiledSet,
+    ignored_regions: &[RegionSpan],
+    lines_to_add: &mut BTreeSet<String>,
+) {
+    if let Some(pattern) = &rule.file_pattern {
+        let file_name = file
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if !pattern.is_match(file_name) {
+            return;
+        }
+    }
+    if let Some(pattern) = &rule.content_pattern
+        && !pattern.is_match(content)
+    {
+        return;
+    }
+    if let Some(pattern) = &rule.content_exclude_pattern
+        && pattern.is_match(content)
+    {
+        return;
+    }
+
+    let replacement = rule
+        .replacement
+        .as_deref()
+        .or(set.replacement.as_deref())
+        .unwrap_or("$0");
+    rewrite_lines(
+        content,
+        &rule.pattern,
+        replacement,
+        &rule.add_lines,
+        &RewriteOptions {
+            line_exclude: rule.line_exclude_pattern.as_ref(),
+            skip_line: set.skip_line_pattern.as_ref(),
+            ignore_regions: ignored_regions,
+        },
+        lines_to_add,
+    );
+}
+
+fn apply_derived_rule(
+    content: &mut String,
+    rule: &CompiledDerivedRule,
+    set: &CompiledSet,
+    ignored_regions: &[RegionSpan],
+    lines_to_add: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    let mut bindings = Vec::new();
+    for (line_index, line) in content.lines().enumerate() {
+        if ignored_regions
+            .iter()
+            .any(|region| region.contains(line_index))
+        {
+            continue;
+        }
+        let Some(captures) = rule.source_pattern.captures(line.trim()) else {
+            continue;
+        };
+        if rule
+            .source_exclude_pattern
+            .as_ref()
+            .is_some_and(|pattern| pattern.is_match(line.trim()))
+        {
+            continue;
+        }
+        let mut values = HashMap::new();
+        for name in rule.source_pattern.capture_names().flatten() {
+            if let Some(value) = captures.name(name) {
+                values.insert(name.to_string(), value.as_str().to_string());
+            }
+        }
+        bindings.push(values);
+    }
+
+    for values in bindings {
+        let pattern = substitute_placeholders(&rule.pattern, &values, true);
+        let regex = Regex::new(&pattern)
+            .map_err(|error| format!("invalid derived pattern {pattern:?}: {error}"))?;
+        let replacement_template = rule
+            .replacement
+            .as_deref()
+            .or(set.replacement.as_deref())
+            .unwrap_or("$0");
+        let replacement = substitute_placeholders(replacement_template, &values, false);
+        let add_lines: Vec<String> = rule
+            .add_lines
+            .iter()
+            .map(|line| substitute_placeholders(line, &values, false))
+            .collect();
+        rewrite_lines(
+            content,
+            &regex,
+            &replacement,
+            &add_lines,
+            &RewriteOptions {
+                line_exclude: None,
+                skip_line: set.skip_line_pattern.as_ref(),
+                ignore_regions: ignored_regions,
+            },
+            lines_to_add,
+        );
+    }
+    Ok(())
+}
+
+fn rewrite_lines(
+    content: &mut String,
+    regex: &Regex,
+    replacement: &str,
+    add_lines: &[String],
+    options: &RewriteOptions<'_>,
+    lines_to_add: &mut BTreeSet<String>,
+) {
+    let trailing_newline = content.ends_with('\n');
+    let mut lines: Vec<String> = content.lines().map(ToString::to_string).collect();
+    for index in 0..lines.len() {
+        if options
+            .ignore_regions
+            .iter()
+            .any(|region| region.contains(index))
+        {
+            continue;
+        }
+        if options
+            .skip_line
+            .is_some_and(|pattern| pattern.is_match(&lines[index]))
+        {
+            continue;
+        }
+        if options.line_exclude.is_some_and(|pattern| {
+            let start = index.saturating_sub(3);
+            let context = lines[start..=index]
+                .iter()
+                .map(|line| line.trim())
+                .collect::<Vec<_>>()
+                .join(" ");
+            pattern.is_match(&context)
+        }) {
+            continue;
+        }
+
+        let mut matched = false;
+        let replaced = regex.replace_all(&lines[index], |captures: &Captures<'_>| {
+            matched = true;
+            for line in add_lines {
+                let mut expanded = String::new();
+                captures.expand(line, &mut expanded);
+                lines_to_add.insert(expanded);
+            }
+            let mut expanded = String::new();
+            captures.expand(replacement, &mut expanded);
+            expanded
+        });
+        if matched {
+            lines[index] = replaced.into_owned();
+        }
+    }
+
+    *content = lines.join("\n");
+    if trailing_newline {
+        content.push('\n');
+    }
+}
+
+fn substitute_placeholders(
+    template: &str,
+    values: &HashMap<String, String>,
+    escape: bool,
+) -> String {
+    let mut output = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        output.push_str(&rest[..start]);
+        let Some(end) = rest[start + 1..].find('}') else {
+            output.push_str(&rest[start..]);
+            break;
+        };
+        let end = start + 1 + end;
+        let name = &rest[start + 1..end];
+        if let Some(value) = values.get(name) {
+            if escape {
+                output.push_str(&regex::escape(value));
+            } else {
+                output.push_str(value);
+            }
+        } else {
+            output.push_str(&rest[start..=end]);
+        }
+        rest = &rest[end + 1..];
+    }
+    output.push_str(rest);
+    output
+}
+
+fn insert_lines(
+    content: &str,
+    lines_to_add: BTreeSet<String>,
+    set: &CompiledSet,
+) -> Result<String, String> {
+    if lines_to_add.is_empty() {
+        return Ok(content.to_string());
+    }
+    let trailing_newline = content.ends_with('\n');
+    let mut lines: Vec<String> = content.lines().map(ToString::to_string).collect();
+    let existing: BTreeSet<&str> = lines.iter().map(String::as_str).collect();
+    let additions: Vec<String> = lines_to_add
+        .into_iter()
+        .filter(|line| !existing.contains(line.as_str()))
+        .collect();
+    if additions.is_empty() {
+        return Ok(content.to_string());
+    }
+
+    let insertion_index = set
+        .add_lines_before_pattern
+        .as_ref()
+        .and_then(|pattern| lines.iter().position(|line| pattern.is_match(line)))
+        .or_else(|| {
+            set.add_lines_fallback_after_pattern
+                .as_ref()
+                .and_then(|pattern| lines.iter().position(|line| pattern.is_match(line)))
+                .map(|index| index + 1)
+        })
+        .unwrap_or(0);
+    for (offset, line) in additions.into_iter().enumerate() {
+        lines.insert(insertion_index + offset, line);
+    }
+
+    let mut output = lines.join("\n");
+    if trailing_newline {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(pattern: &str, add_line: &str) -> RegexReplaceRuleConfig {
+        RegexReplaceRuleConfig {
+            pattern: pattern.to_string(),
+            replacement: None,
+            add_lines: vec![add_line.to_string()],
+            content_pattern: None,
+            line_exclude_pattern: None,
+            file_pattern: None,
+            content_exclude_pattern: None,
+        }
+    }
+
+    fn config(rule: RegexReplaceRuleConfig) -> RegexReplaceConfig {
+        RegexReplaceConfig {
+            patterns: vec![],
+            exclude: vec![],
+            sets: vec![RegexReplaceSetConfig {
+                name: "test".to_string(),
+                replacement: Some("$1".to_string()),
+                rules: vec![rule],
+                add_lines_before_pattern: Some("^use ".to_string()),
+                skip_line_pattern: Some("^use ".to_string()),
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn rewrites_text_and_adds_a_line() {
+        let input = "use foo.bar;\n\nvalue = foo.bar(value);\n";
+        let output = rewrite(
+            input,
+            Path::new("example.txt"),
+            &config(rule(r"\bfoo\.(bar)\b", "use static foo.$1;")),
+        )
+        .unwrap();
+        assert_eq!(
+            output,
+            "use static foo.bar;\nuse foo.bar;\n\nvalue = bar(value);\n"
+        );
+    }
+
+    #[test]
+    fn honors_content_and_line_exclusions() {
+        let mut configured = rule(r"\bfoo\.(bar)\b", "use static foo.$1;");
+        configured.content_exclude_pattern = Some("skip-file".to_string());
+        configured.line_exclude_pattern = Some("keep".to_string());
+        let cfg = config(configured);
+        let input =
+            "use foo.bar;\n// keep foo.bar here\none\ntwo\nthree\nvalue = foo.bar(value);\n";
+        let output = rewrite(input, Path::new("example.txt"), &cfg).unwrap();
+        assert!(output.contains("// keep foo.bar here"));
+        assert!(output.contains("value = bar(value);"));
+    }
+
+    #[test]
+    fn ignores_configured_regions() {
+        let mut cfg = config(rule(r"\bfoo\.(bar)\b", "use static foo.$1;"));
+        cfg.sets[0].ignore_regions = vec![RegexReplaceIgnoreRegionConfig {
+            start_pattern: "^BEGIN$".to_string(),
+            end_pattern: "^END$".to_string(),
+        }];
+        let input = "BEGIN\nvalue = foo.bar(value);\nEND\nvalue = foo.bar(value);\n";
+        let output = rewrite(input, Path::new("example.txt"), &cfg).unwrap();
+        assert_eq!(
+            output,
+            "use static foo.bar;\nBEGIN\nvalue = foo.bar(value);\nEND\nvalue = bar(value);\n"
+        );
+    }
+
+    #[test]
+    fn derives_rules_from_named_source_captures() {
+        let cfg = RegexReplaceConfig {
+            patterns: vec![],
+            exclude: vec![],
+            sets: vec![RegexReplaceSetConfig {
+                name: "derived".to_string(),
+                replacement: Some("$1".to_string()),
+                derived_rules: vec![DerivedRegexReplaceRuleConfig {
+                    source_pattern: r"^use (?P<module>[a-z.]+)\.(?P<name>[A-Z][A-Za-z0-9]+);$"
+                        .to_string(),
+                    pattern: r"\b{name}\.([A-Z_]+)\b".to_string(),
+                    replacement: None,
+                    add_lines: vec!["use static {module}.$1;".to_string()],
+                    source_exclude_pattern: None,
+                }],
+                add_lines_before_pattern: Some("^use ".to_string()),
+                skip_line_pattern: Some(r"^use ".to_string()),
+                ..Default::default()
+            }],
+        };
+        let input = "use example.mod.Constants;\n\nvalue = Constants.VALUE;\n";
+        let output = rewrite(input, Path::new("example.txt"), &cfg).unwrap();
+        assert_eq!(
+            output,
+            "use static example.mod.VALUE;\nuse example.mod.Constants;\n\nvalue = VALUE;\n"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod hook;
 mod init;
 mod linters;
 mod project_root;
+mod regions;
 mod registry;
 mod runner;
 mod setup;
@@ -1370,6 +1371,7 @@ biome-format          biome               active         fast      yes  Format J
 cargo-clippy          cargo-clippy        active         fast      yes  Lint Rust code; runs on all .rs files, not just changed              *.rs
 cargo-fmt             rustfmt             active         fast      yes  Format Rust code; runs on all .rs files, not just changed            *.rs
 gofmt                 gofmt               missing        fast      yes  Format Go code                                                       *.go
+regex-replace         (built-in)          not configured  fast      yes  Apply configured regular-expression replacements to source files
 google-java-format    google-java-format  missing        fast      yes  Format Java code                                                     *.java
 ktlint                ktlint              missing        fast      yes  Lint and format Kotlin code                                          *.kt *.kts
 dotnet-format         dotnet              missing        fast      yes  Format C# code                                                       *.cs

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -1,0 +1,162 @@
+//! Utilities for checks that need to reason about marked regions of a file.
+
+use std::fmt;
+
+/// A pair of lines marking a protected region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RegionSpan {
+    /// Index of the configured marker pair that produced this span.
+    pub marker_index: usize,
+    /// Line containing the start marker.
+    pub start_line: usize,
+    /// Line containing the end marker.
+    pub end_line: usize,
+}
+
+impl RegionSpan {
+    /// Returns whether `line` is within the marked region, including its
+    /// boundary lines.
+    pub(crate) fn contains(self, line: usize) -> bool {
+        (self.start_line..=self.end_line).contains(&line)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RegionError {
+    EndWithoutStart { marker_index: usize, line: usize },
+    StartWithoutEnd { marker_index: usize, line: usize },
+}
+
+impl fmt::Display for RegionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EndWithoutStart {
+                marker_index, line, ..
+            } => write!(
+                f,
+                "region marker pair {marker_index} has an end marker on line {} without a start marker",
+                line + 1
+            ),
+            Self::StartWithoutEnd {
+                marker_index, line, ..
+            } => write!(
+                f,
+                "region marker pair {marker_index} starts on line {} without an end marker",
+                line + 1
+            ),
+        }
+    }
+}
+
+/// Finds marked regions in `lines` using caller-provided marker matching.
+///
+/// Keeping matching outside this utility makes it usable with literal marker
+/// strings, regular expressions, or another syntax-aware matcher without
+/// making the region handling language-specific. Each marker pair is tracked
+/// independently, so regions from different pairs may overlap.
+pub(crate) fn find_region_spans<T>(
+    lines: &[&str],
+    markers: &[T],
+    mut is_start: impl FnMut(&T, &str) -> bool,
+    mut is_end: impl FnMut(&T, &str) -> bool,
+) -> Result<Vec<RegionSpan>, RegionError> {
+    let mut open = vec![None; markers.len()];
+    let mut spans = Vec::new();
+
+    for (line, content) in lines.iter().enumerate() {
+        for (marker_index, marker) in markers.iter().enumerate() {
+            let starts = is_start(marker, content);
+            let ends = is_end(marker, content);
+
+            match (open[marker_index], starts, ends) {
+                (None, false, false) => {}
+                (None, false, true) => {
+                    return Err(RegionError::EndWithoutStart { marker_index, line });
+                }
+                (None, true, true) => {
+                    spans.push(RegionSpan {
+                        marker_index,
+                        start_line: line,
+                        end_line: line,
+                    });
+                }
+                (None, true, false) => {
+                    open[marker_index] = Some(line);
+                }
+                (Some(start_line), _, true) => {
+                    spans.push(RegionSpan {
+                        marker_index,
+                        start_line,
+                        end_line: line,
+                    });
+                    open[marker_index] = None;
+                }
+                (Some(_), false, false) => {}
+                // A nested start marker for the same pair does not change the
+                // active region. This matches the usual off/on convention.
+                (Some(_), true, false) => {}
+            }
+        }
+    }
+
+    if let Some((marker_index, Some(line))) =
+        open.iter().enumerate().find(|(_, line)| line.is_some())
+    {
+        return Err(RegionError::StartWithoutEnd {
+            marker_index,
+            line: *line,
+        });
+    }
+
+    Ok(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_multiple_marker_pairs() {
+        let lines = ["before", "BEGIN", "inside", "END", "after"];
+        let markers = [("BEGIN", "END")];
+        let spans = find_region_spans(
+            &lines,
+            &markers,
+            |marker, line| line == marker.0,
+            |marker, line| line == marker.1,
+        )
+        .unwrap();
+
+        assert_eq!(
+            spans,
+            vec![RegionSpan {
+                marker_index: 0,
+                start_line: 1,
+                end_line: 3,
+            }]
+        );
+        assert!(spans[0].contains(2));
+        assert!(!spans[0].contains(4));
+    }
+
+    #[test]
+    fn reports_unbalanced_markers() {
+        let lines = ["BEGIN", "inside"];
+        let markers = [("BEGIN", "END")];
+        let error = find_region_spans(
+            &lines,
+            &markers,
+            |marker, line| line == marker.0,
+            |marker, line| line == marker.1,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            RegionError::StartWithoutEnd {
+                marker_index: 0,
+                line: 0,
+            }
+        );
+    }
+}

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -2,7 +2,7 @@ use super::types::{
     Check, ConfigFile, EditorconfigDirectiveStyle, OverviewRole, OverviewSection, WorkflowSetup,
 };
 use crate::linters::{
-    biome, flint_setup, license_header, lychee, renovate_deps,
+    biome, flint_setup, google_java_format, license_header, lychee, regex_replace, renovate_deps,
     renovate_deps::RENOVATE_CONFIG_PATTERNS, rumdl, rustfmt, taplo, typos, yamllint,
 };
 const TOOL_RUMDL: &[&str] = &["tool", "rumdl"];
@@ -568,32 +568,35 @@ fn check_gofmt() -> Check {
 }
 
 fn check_google_java_format() -> Check {
-    Check::files(
-        "google-java-format",
-        "google-java-format --dry-run --set-exit-if-changed {FILES}",
-        &["*.java"],
-    )
-    .fix("google-java-format -i {FILES}")
-    .mise_tool("google-java-format")
-    .formatter()
-    .editorconfig_line_length_off(
-        &["*.java"],
-        "Java line length is handled by google-java-format",
-        Some(EditorconfigDirectiveStyle::Slash),
-    )
-    .migrate_tool_keys(&[
-        "ubi:google/google-java-format",
-        "github:google/google-java-format",
-    ])
-    .project_url(GOOGLE_JAVA_FORMAT_URL)
-    .overview(
-        OverviewSection::Languages,
-        "Java",
-        OverviewRole::Formatter,
-        None,
-    )
-    .desc("Format Java code")
-    .lang()
+    Check::native(&google_java_format::CHECK_TYPE)
+        .patterns(&["*.java"])
+        .mise_tool("google-java-format")
+        .formatter()
+        .editorconfig_line_length_off(
+            &["*.java"],
+            "Java line length is handled by google-java-format",
+            Some(EditorconfigDirectiveStyle::Slash),
+        )
+        .migrate_tool_keys(&[
+            "ubi:google/google-java-format",
+            "github:google/google-java-format",
+        ])
+        .project_url(GOOGLE_JAVA_FORMAT_URL)
+        .overview(
+            OverviewSection::Languages,
+            "Java",
+            OverviewRole::Formatter,
+            None,
+        )
+        .desc("Format Java code")
+        .lang()
+}
+
+fn check_regex_replace() -> Check {
+    Check::native(&regex_replace::CHECK_TYPE)
+        .activate_unconditionally()
+        .status_hook(regex_replace::status)
+        .desc("Apply configured regular-expression replacements to source files")
 }
 
 fn check_ktlint() -> Check {
@@ -722,6 +725,7 @@ pub fn builtin() -> Vec<Check> {
         check_cargo_clippy(),
         check_cargo_fmt(),
         check_gofmt(),
+        check_regex_replace(),
         check_google_java_format(),
         check_ktlint(),
         check_dotnet_format(),

--- a/tests/cases/regex-replace/auto-fix/files/Main.txt
+++ b/tests/cases/regex-replace/auto-fix/files/Main.txt
@@ -1,0 +1,1 @@
+value = foo.bar(value);

--- a/tests/cases/regex-replace/auto-fix/files/flint.toml
+++ b/tests/cases/regex-replace/auto-fix/files/flint.toml
@@ -1,0 +1,12 @@
+[checks.regex-replace]
+patterns = ["*.txt"]
+
+[[checks.regex-replace.sets]]
+name = "test"
+replacement = '$1'
+add_lines_before_pattern = '^use '
+skip_line_pattern = '^use '
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bfoo\.(bar)\b'
+add_lines = ['use static foo.$1;']

--- a/tests/cases/regex-replace/auto-fix/test.toml
+++ b/tests/cases/regex-replace/auto-fix/test.toml
@@ -1,0 +1,12 @@
+[expected]
+args = "run --full --fix regex-replace"
+exit = 1
+stderr = '''
+flint: fixed: regex-replace — commit before pushing
+'''
+
+[expected.files]
+"Main.txt" = """
+use static foo.bar;
+value = bar(value);
+"""

--- a/tests/cases/regex-replace/clean/files/Main.txt
+++ b/tests/cases/regex-replace/clean/files/Main.txt
@@ -1,0 +1,2 @@
+use static foo.bar;
+value = bar(value);

--- a/tests/cases/regex-replace/clean/files/flint.toml
+++ b/tests/cases/regex-replace/clean/files/flint.toml
@@ -1,0 +1,12 @@
+[checks.regex-replace]
+patterns = ["*.txt"]
+
+[[checks.regex-replace.sets]]
+name = "test"
+replacement = '$1'
+add_lines_before_pattern = '^use '
+skip_line_pattern = '^use '
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bfoo\.(bar)\b'
+add_lines = ['use static foo.$1;']

--- a/tests/cases/regex-replace/clean/test.toml
+++ b/tests/cases/regex-replace/clean/test.toml
@@ -1,0 +1,3 @@
+[expected]
+args = "run --full regex-replace"
+exit = 0

--- a/tests/cases/regex-replace/failure/files/Main.txt
+++ b/tests/cases/regex-replace/failure/files/Main.txt
@@ -1,0 +1,1 @@
+value = foo.bar(value);

--- a/tests/cases/regex-replace/failure/files/flint.toml
+++ b/tests/cases/regex-replace/failure/files/flint.toml
@@ -1,0 +1,12 @@
+[checks.regex-replace]
+patterns = ["*.txt"]
+
+[[checks.regex-replace.sets]]
+name = "test"
+replacement = '$1'
+add_lines_before_pattern = '^use '
+skip_line_pattern = '^use '
+
+[[checks.regex-replace.sets.rules]]
+pattern = '\bfoo\.(bar)\b'
+add_lines = ['use static foo.$1;']

--- a/tests/cases/regex-replace/failure/test.toml
+++ b/tests/cases/regex-replace/failure/test.toml
@@ -1,0 +1,10 @@
+[expected]
+args = "run --full regex-replace"
+exit = 1
+stderr = '''
+[regex-replace]
+Main.txt: regex replacements are not formatted
+
+flint: 1 check failed (regex-replace)
+💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
+'''


### PR DESCRIPTION
## Summary

- add native `google-java-format` support with configurable GJF options
- preserve configured formatter-off regions
- add generic, set-based `regex-replace` rules with file scopes, defaults, filters, insertions, and derived rules
- add native license-header file exclusions and shared glob semantics
- document the regex linter with a realistic static-import migration example

This enables consumers to replace Spotless-specific Java formatting and custom static-import formatters with Flint configuration.

## Companion PRs

The corresponding consumer migration is [open-telemetry/opentelemetry-java-instrumentation#19242](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19242).

That PR pins Flint to this commit while the feature is unreleased. A small part of its Java source diff is expected formatter output from upgrading to google-java-format 1.35.0, rather than a behavior change in the migration itself.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `mise run lint:fix`
- `mise run lint`
- `cargo fmt --check`
- `git diff --check`
