### PR TITLE
docs: document semantic PR title guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Pull request titles should follow the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format:
 
 ```text
-<type>[optional scope]: <description>
+<type>(optional scope): <description>
 ```
 
 For example: `feat(format): support Java formatting`. Common types include `feat`, `fix`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing to Flint
 
+Pull request titles should follow the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format:
+
+```text
+<type>[optional scope]: <description>
+```
+
+For example: `feat(format): support Java formatting`. Common types include `feat`, `fix`,
+`docs`, `test`, `refactor`, `perf`, `build`, `ci`, `chore`, and `revert`.
+
 ## Local development
 
 If you are working on Flint itself, the normal local workflow is:


### PR DESCRIPTION
## Summary

- Document the Conventional Commits-style pull request title format.
- Add examples and common title types for contributors.

## Validation

- `git diff --check`
- `mise run lint`
- `mise run lint:fix` (push hook)
