### PR TITLE
docs: record Flint v2 architecture decisions

### DIFF
--- a/docs/adr/0001-curated-registry.md
+++ b/docs/adr/0001-curated-registry.md
@@ -1,0 +1,41 @@
+# ADR 0001: Flint is a curated registry and orchestrator
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+
+## Context
+
+Flint needs to provide fast, consistent local and CI linting without becoming
+another generic task runner. Repositories already have `mise` for installing
+tools and composing arbitrary tasks.
+
+## Decision
+
+Flint uses a built-in, compiled registry of curated checks. The registry owns
+the check's execution model, file selection, configuration integration, fix
+behavior, setup hooks, and documentation metadata.
+
+Flint is not a generic command wrapper, a repo-local plugin loader, or a
+replacement for a build system. New built-in checks must be implemented in the
+Flint codebase and reviewed as part of the registry.
+
+The registry also owns canonical external backend keys. A scheduled
+`mise run validate-mise-registry` file task resolves those backends through the
+current mise registry, while normal registry tests remain network-free.
+Non-Aqua backends are explicit, documented exceptions rather than accidental
+registry lookups.
+
+## Consequences
+
+- Every check can have consistent local/CI behavior and cross-platform handling.
+- Registry entries need complete metadata and tests.
+- A repository cannot add an arbitrary Flint check only through `flint.toml`.
+- Tools that require build-graph or compiler-plugin integration may need a new
+  explicit check abstraction instead of a normal template entry.
+
+## Alternatives considered
+
+- A generic command list in `flint.toml` would duplicate `mise` and weaken
+  Flint's consistency guarantees.
+- A plugin system would add versioning, security, and cross-platform complexity
+  that is outside Flint's current scope.

--- a/docs/adr/0002-check-ownership-and-fixer-conflicts.md
+++ b/docs/adr/0002-check-ownership-and-fixer-conflicts.md
@@ -1,0 +1,42 @@
+# ADR 0002: Check ownership and fixer conflicts
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+
+## Context
+
+Checks often share file extensions without having the same responsibility. For
+example, YAML style and Kubernetes policy checks may both inspect a file, while
+a formatter and another formatter may both try to rewrite it.
+
+## Decision
+
+Registry metadata distinguishes these relationships:
+
+- **formatter:** owns formatting and may be the explicit deferral target for a
+  generic formatting check;
+- **generic linter:** validates syntax or general style;
+- **semantic linter:** validates domain-specific rules and may complement a
+  generic linter;
+- **project check:** evaluates repository-wide state rather than individual
+  file ownership.
+
+Overlapping read-only checks are allowed when their responsibilities are
+documented. Formatter deferral must be explicit in the registry. Two
+fix-capable checks must not silently rewrite the same file in an
+order-dependent way; they must have disjoint fix ownership, an explicit safe
+precedence, or a reported conflict.
+
+## Consequences
+
+- `ryl` and `kube-linter` may both inspect Kubernetes YAML.
+- `google-java-format` and a read-only Checkstyle check may both inspect Java.
+- `flint run --fix` must preserve deterministic write ordering and conflict
+  reporting.
+- New registry entries require ownership and fixer-conflict tests.
+
+## Alternatives considered
+
+- A strict one-check-per-file rule would prevent useful complementary checks.
+- Implicit last-writer-wins behavior would make fixes fragile and difficult to
+  review.

--- a/docs/adr/0003-check-execution-and-setup-outcomes.md
+++ b/docs/adr/0003-check-execution-and-setup-outcomes.md
@@ -1,0 +1,36 @@
+# ADR 0003: Check execution and setup outcomes
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+
+## Context
+
+Read-only checks benefit from parallel execution, but concurrent fixers can
+corrupt or overwrite each other's changes. Flint setup drift also differs from
+ordinary lint failures: some setup changes are safe to apply before continuing,
+while setup migrations can add, remove, or replace the lint tools that
+determine which checks are enabled.
+
+## Decision
+
+- Normal read-only checks run in parallel and collect deterministic, sorted
+  output.
+- Fixing checks run serially.
+- Non-blocking setup convergence, such as canonical tool ordering, is applied
+  before continuing with independent fixes.
+- Blocking or fatal setup migrations stop the fix run with a clear reason.
+- Fix results remain classified as `clean`, `fixed`, `review`, or `partial`.
+
+## Consequences
+
+- Check mode stays fast.
+- Fix mode is deterministic and avoids concurrent writes.
+- Setup normalization does not prevent unrelated linter fixes.
+- Some setup failures intentionally require a second command or manual review.
+
+## Alternatives considered
+
+- Running all fixers in parallel would be faster but unsafe for overlapping
+  files.
+- Treating every setup warning as blocking would make harmless ordering drift
+  prevent useful fixes.

--- a/docs/adr/0004-canonical-configuration-and-migrations.md
+++ b/docs/adr/0004-canonical-configuration-and-migrations.md
@@ -1,0 +1,40 @@
+# ADR 0004: Canonical configuration and migrations
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+
+## Context
+
+Tool auto-discovery creates local/CI drift and makes migrations difficult to
+reason about. Flint needs a predictable configuration layout while preserving
+intentional repository-specific settings.
+
+## Decision
+
+- Each supported check has one canonical config filename and documented config
+  location.
+- `FLINT_CONFIG_DIR` controls the shared Flint-managed directory where the
+  check supports it; documented root-level exceptions remain explicit.
+- Repo-wide excludes belong in `flint.toml`; tool-specific rules belong in the
+  tool's own config.
+- Setup migrations are versioned and idempotent.
+- `flint-setup` applies actionable Flint-owned migrations; `flint init` is the
+  explicit full-convergence path.
+- Migrations preserve meaningful reviewer-facing comments where possible and
+  report when manual review is needed.
+
+## Consequences
+
+- Flint fails clearly instead of silently using an unsupported alternate config.
+- Repeated setup runs should produce no unrelated churn.
+- Migration code must use targeted edits when full-file regeneration would lose
+  important context.
+- Existing repository-specific configuration may require an explicit migration
+  rather than implicit discovery.
+
+## Alternatives considered
+
+- Supporting every upstream discovery filename would make local/CI behavior
+  difficult to predict.
+- Rewriting all config files would be simpler but would discard useful comments
+  and reviewer context.

--- a/docs/adr/0005-changed-file-relevance-and-baselines.md
+++ b/docs/adr/0005-changed-file-relevance-and-baselines.md
@@ -1,0 +1,46 @@
+# ADR 0005: Changed-file relevance and baselines
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+
+## Context
+
+Flint's local default should be fast and diff-aware. CI activates the complete
+active check set, including adaptive checks, while retaining changed-file
+scoping where each check supports it. Explicit `--full` runs provide complete
+file coverage. Some changes affect the meaning of all files, and deleted paths
+can still affect a check's relevance.
+
+## Decision
+
+Flint keeps two related inputs:
+
+- the runnable file list, containing existing tracked files that can be passed
+  to external tools;
+- the changed-path list, retaining created, modified, renamed, and deleted
+  paths for relevance and baseline decisions.
+
+A check expands to a full baseline when its activation, version, supported
+config, Flint-managed settings, or other declared baseline trigger changes.
+Adaptive checks may skip local runs only when their relevance hook says the
+changed paths cannot affect the result. CI includes those checks, but is not
+equivalent to `--full`: file coverage remains diff-aware where supported.
+
+Adaptive relevance is a speculative optimization for local feedback speed, not
+a correctness boundary. A hook may skip an expensive check only when it can
+conservatively establish that the changed paths cannot affect the result.
+Uncertain or malformed state must trigger the check rather than skip it.
+
+## Consequences
+
+- Deleting a file can correctly trigger a check without passing a missing path
+  to the external tool.
+- New checks need explicit relevance and baseline behavior.
+- Relevance logic must be tested separately for added, modified, renamed, and
+  deleted paths.
+
+## Alternatives considered
+
+- Using only existing runnable files loses deletion-only changes.
+- Always running every check locally would preserve coverage but violate
+  Flint's fast inner-loop goal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records
+
+These ADRs are the source of truth for accepted Flint architecture decisions.
+
+- [0001 — Flint is a curated registry](0001-curated-registry.md)
+- [0002 — Check ownership and fixer conflicts](0002-check-ownership-and-fixer-conflicts.md)
+- [0003 — Check execution and setup outcomes](0003-check-execution-and-setup-outcomes.md)
+- [0004 — Canonical configuration and migrations](0004-canonical-configuration-and-migrations.md)
+- [0005 — Changed-file relevance and baselines](0005-changed-file-relevance-and-baselines.md)
+
+Code and tests are authoritative for implemented behavior. User-facing
+documentation describes current usage, and the work tracker describes status
+and backlog.


### PR DESCRIPTION
## Summary

- record the accepted Flint v2 architecture in ADRs
- document registry curation, ownership, execution/setup outcomes, migrations, and changed-file relevance
- establish ADRs as the source of truth for accepted design decisions

This PR is documentation-only and intentionally does not change runtime behavior.

## Validation

- `mise run lint:fix`
