### PR TITLE
feat: define registry and execution contracts

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,7 +2,7 @@
 
 These ADRs are the source of truth for accepted Flint architecture decisions.
 
-- [0001 — Flint is a curated registry](0001-curated-registry.md)
+- [0001 — Flint is a curated registry and orchestrator](0001-curated-registry.md)
 - [0002 — Check ownership and fixer conflicts](0002-check-ownership-and-fixer-conflicts.md)
 - [0003 — Check execution and setup outcomes](0003-check-execution-and-setup-outcomes.md)
 - [0004 — Canonical configuration and migrations](0004-canonical-configuration-and-migrations.md)

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -165,6 +165,7 @@ fn check_shellcheck() -> Check {
 fn check_shfmt() -> Check {
     Check::file("shfmt", "shfmt -d {FILE}", &["*.sh", "*.bash"])
         .fix("shfmt -w {FILE}")
+        .fix_order(10)
         .project_url(SHFMT_URL)
         .overview(
             OverviewSection::FilesFormats,
@@ -181,6 +182,7 @@ fn check_shfmt() -> Check {
 fn check_rumdl() -> Check {
     Check::files("rumdl", "rumdl check {FILES}", &["*.md"])
         .fix("rumdl check --fix {FILES}")
+        .fix_order(20)
         .linter_config(".rumdl.toml", "--config")
         .baseline_config(ConfigFile::config_dir(".rumdl.toml"))
         .unsupported_configs(RUMDL_UNSUPPORTED_CONFIGS)
@@ -206,6 +208,7 @@ fn check_rumdl() -> Check {
 fn check_yaml_lint() -> Check {
     Check::files("ryl", "ryl {FILES}", &["*.yml", "*.yaml"])
         .fix("ryl --fix {FILES}")
+        .fix_order(30)
         .linter_config(".yamllint.yml", "-c")
         .baseline_config(ConfigFile::config_dir(".yamllint.yml"))
         .unsupported_configs(YAMLLINT_UNSUPPORTED_CONFIGS)
@@ -231,6 +234,7 @@ fn check_taplo() -> Check {
         &["*.toml"],
     )
     .fix("taplo fmt {CONFIG_ARGS} {FILE}")
+    .fix_order(40)
     .linter_config(".taplo.toml", "--config")
     .baseline_config(ConfigFile::config_dir(".taplo.toml"))
     .unsupported_configs(TAPLO_UNSUPPORTED_CONFIGS)
@@ -279,6 +283,7 @@ fn check_actionlint() -> Check {
         None,
     )
     .desc("Lint GitHub Actions workflow files")
+    .semantic()
     .style()
 }
 
@@ -289,6 +294,7 @@ fn check_zizmor() -> Check {
         &[".github/workflows/*.yml", ".github/workflows/*.yaml"],
     )
     .fix("zizmor --fix {FILES}")
+    .fix_order(50)
     .linter_config("zizmor.yml", "--config")
     .baseline_config(ConfigFile::config_dir("zizmor.yml"))
     .unsupported_configs(ZIZMOR_UNSUPPORTED_CONFIGS)
@@ -318,6 +324,7 @@ fn check_zizmor() -> Check {
         stays invisible until something edits them. Run `flint run --full`\n\
         periodically (e.g. weekly `schedule:` workflow) to catch this.",
     )
+    .semantic()
     .style()
 }
 
@@ -359,6 +366,7 @@ fn check_xmllint() -> Check {
 fn check_typos() -> Check {
     Check::files("typos", "typos --force-exclude {FILES}", &["*"])
         .fix("typos --write-changes --force-exclude {FILES}")
+        .fix_order(60)
         .linter_config("_typos.toml", "--config")
         .baseline_config(ConfigFile::config_dir("_typos.toml"))
         .unsupported_configs(TYPOS_UNSUPPORTED_CONFIGS)
@@ -427,12 +435,14 @@ fn check_golangci_lint() -> Check {
     .config_doc_url(GOLANGCI_LINT_CONFIG_URL)
     .overview(OverviewSection::Languages, "Go", OverviewRole::Linter, None)
     .desc("Lint Go code; uses --new-from-rev to scope analysis to changed code")
+    .project_ownership()
     .lang()
 }
 
 fn check_ruff() -> Check {
     Check::file("ruff", "ruff check {FILE}", &["*.py"])
         .fix("ruff check --fix {FILE}")
+        .fix_order(70)
         .linter_config("ruff.toml", "--config")
         .baseline_config(RUFF_BASELINE_CONFIG)
         .unsupported_configs(RUFF_UNSUPPORTED_CONFIGS)
@@ -453,6 +463,7 @@ fn check_ruff_format() -> Check {
     Check::file("ruff-format", "ruff format --check {FILE}", &["*.py"])
         .bin("ruff")
         .fix("ruff format {FILE}")
+        .fix_order(80)
         .linter_config("ruff.toml", "--config")
         .baseline_config(RUFF_BASELINE_CONFIG)
         .unsupported_configs(RUFF_UNSUPPORTED_CONFIGS)
@@ -477,6 +488,7 @@ fn check_biome() -> Check {
         &["*.json", "*.jsonc", "*.js", "*.ts", "*.jsx", "*.tsx"],
     )
     .fix("biome check --fix {FILE}")
+    .fix_order(90)
     .baseline_config(BIOME_BASELINE_CONFIG)
     .unsupported_configs(BIOME_UNSUPPORTED_CONFIGS)
     .project_url(BIOME_URL)
@@ -507,6 +519,7 @@ fn check_biome_format() -> Check {
     )
     .bin("biome")
     .fix("biome format --write {FILE}")
+    .fix_order(100)
     .baseline_config(BIOME_BASELINE_CONFIG)
     .unsupported_configs(BIOME_UNSUPPORTED_CONFIGS)
     .project_url(BIOME_URL)
@@ -537,6 +550,7 @@ fn check_cargo_clippy() -> Check {
         &["*.rs"],
     )
     .fix("cargo clippy -q --all-targets --fix --allow-dirty --allow-staged -- -D warnings")
+    .fix_order(110)
     .partial_fix()
     .mise_tool("rust")
     .toolchain_components("clippy")
@@ -553,12 +567,14 @@ fn check_cargo_clippy() -> Check {
         None,
     )
     .desc("Lint Rust code; runs on all .rs files, not just changed")
+    .project_ownership()
     .lang()
 }
 
 fn check_cargo_fmt() -> Check {
     Check::project("cargo-fmt", "cargo fmt -- {CONFIG_ARGS} --check", &["*.rs"])
         .fix("cargo fmt -- {CONFIG_ARGS}")
+        .fix_order(120)
         .linter_config("rustfmt.toml", "--config-path")
         .baseline_config(RUSTFMT_BASELINE_CONFIG)
         .unsupported_configs(RUSTFMT_UNSUPPORTED_CONFIGS)
@@ -585,6 +601,7 @@ fn check_cargo_fmt() -> Check {
 fn check_gofmt() -> Check {
     Check::file("gofmt", "gofmt -d {FILE}", &["*.go"])
         .fix("gofmt -w {FILE}")
+        .fix_order(130)
         .mise_tool("go")
         .toolchain()
         .project_url(GOFMT_URL)
@@ -606,6 +623,7 @@ fn check_google_java_format() -> Check {
         &["*.java"],
     )
     .fix("google-java-format -i {FILES}")
+    .fix_order(140)
     .mise_tool("google-java-format")
     .formatter()
     .editorconfig_line_length_off(
@@ -635,6 +653,7 @@ fn check_ktlint() -> Check {
         &["*.kt", "*.kts"],
     )
     .fix("ktlint --format --log-level=error {FILES}")
+    .fix_order(150)
     .full_cmd(
         "ktlint --log-level=error {ROOT}",
         "ktlint --format --log-level=error {ROOT}",
@@ -662,6 +681,7 @@ fn check_dotnet_format() -> Check {
         &["*.cs"],
     )
     .fix("dotnet format --include {RELFILES}")
+    .fix_order(160)
     .full_cmd("dotnet format --verify-no-changes", "dotnet format")
     .bin("dotnet")
     .mise_tool("dotnet")
@@ -688,6 +708,7 @@ fn check_lychee() -> Check {
             Some("Broken links"),
         )
         .desc("Check for broken links")
+        .project_ownership()
         .docs(
             "Orchestrates [lychee](https://lychee.cli.rs/) for link checking. \
             Requires `lychee` in `[tools]`.\n\
@@ -723,6 +744,7 @@ fn check_lychee() -> Check {
 
 fn check_renovate_deps() -> Check {
     Check::native(&renovate_deps::CHECK_TYPE)
+        .fix_order(170)
         .slow()
         .adaptive_relevance(renovate_deps::adaptive_relevance)
         .mise_tool("npm:renovate")
@@ -735,6 +757,7 @@ fn check_renovate_deps() -> Check {
             Some("Dependency update configuration"),
         )
         .desc("Verify Renovate dependency snapshot is up to date")
+        .project_ownership()
         .docs(
             "Verifies `renovate-tracked-deps.json` next to the active Renovate\n\
             config is up to date by running Renovate locally and comparing its\n\
@@ -799,6 +822,7 @@ fn check_license_header() -> Check {
 
 fn check_flint_setup() -> Check {
     Check::native(&flint_setup::CHECK_TYPE)
+        .fix_order(0)
         .activate_unconditionally()
         .patterns(&["mise.toml"])
         .overview(
@@ -808,6 +832,7 @@ fn check_flint_setup() -> Check {
             Some("Flint-managed setup and `mise.toml` layout"),
         )
         .desc("Keep Flint setup current and mise.toml lint tooling canonical")
+        .project_ownership()
         .docs(
             "Checks the repo's Flint-managed setup state and `mise.toml` layout.\n\
             \n\

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -165,7 +165,6 @@ fn check_shellcheck() -> Check {
 fn check_shfmt() -> Check {
     Check::file("shfmt", "shfmt -d {FILE}", &["*.sh", "*.bash"])
         .fix("shfmt -w {FILE}")
-        .fix_order(10)
         .project_url(SHFMT_URL)
         .overview(
             OverviewSection::FilesFormats,
@@ -182,7 +181,6 @@ fn check_shfmt() -> Check {
 fn check_rumdl() -> Check {
     Check::files("rumdl", "rumdl check {FILES}", &["*.md"])
         .fix("rumdl check --fix {FILES}")
-        .fix_order(20)
         .linter_config(".rumdl.toml", "--config")
         .baseline_config(ConfigFile::config_dir(".rumdl.toml"))
         .unsupported_configs(RUMDL_UNSUPPORTED_CONFIGS)
@@ -208,7 +206,6 @@ fn check_rumdl() -> Check {
 fn check_yaml_lint() -> Check {
     Check::files("ryl", "ryl {FILES}", &["*.yml", "*.yaml"])
         .fix("ryl --fix {FILES}")
-        .fix_order(30)
         .linter_config(".yamllint.yml", "-c")
         .baseline_config(ConfigFile::config_dir(".yamllint.yml"))
         .unsupported_configs(YAMLLINT_UNSUPPORTED_CONFIGS)
@@ -234,7 +231,6 @@ fn check_taplo() -> Check {
         &["*.toml"],
     )
     .fix("taplo fmt {CONFIG_ARGS} {FILE}")
-    .fix_order(40)
     .linter_config(".taplo.toml", "--config")
     .baseline_config(ConfigFile::config_dir(".taplo.toml"))
     .unsupported_configs(TAPLO_UNSUPPORTED_CONFIGS)
@@ -283,7 +279,6 @@ fn check_actionlint() -> Check {
         None,
     )
     .desc("Lint GitHub Actions workflow files")
-    .semantic()
     .style()
 }
 
@@ -294,7 +289,6 @@ fn check_zizmor() -> Check {
         &[".github/workflows/*.yml", ".github/workflows/*.yaml"],
     )
     .fix("zizmor --fix {FILES}")
-    .fix_order(50)
     .linter_config("zizmor.yml", "--config")
     .baseline_config(ConfigFile::config_dir("zizmor.yml"))
     .unsupported_configs(ZIZMOR_UNSUPPORTED_CONFIGS)
@@ -324,7 +318,6 @@ fn check_zizmor() -> Check {
         stays invisible until something edits them. Run `flint run --full`\n\
         periodically (e.g. weekly `schedule:` workflow) to catch this.",
     )
-    .semantic()
     .style()
 }
 
@@ -366,7 +359,6 @@ fn check_xmllint() -> Check {
 fn check_typos() -> Check {
     Check::files("typos", "typos --force-exclude {FILES}", &["*"])
         .fix("typos --write-changes --force-exclude {FILES}")
-        .fix_order(60)
         .linter_config("_typos.toml", "--config")
         .baseline_config(ConfigFile::config_dir("_typos.toml"))
         .unsupported_configs(TYPOS_UNSUPPORTED_CONFIGS)
@@ -435,14 +427,12 @@ fn check_golangci_lint() -> Check {
     .config_doc_url(GOLANGCI_LINT_CONFIG_URL)
     .overview(OverviewSection::Languages, "Go", OverviewRole::Linter, None)
     .desc("Lint Go code; uses --new-from-rev to scope analysis to changed code")
-    .project_ownership()
     .lang()
 }
 
 fn check_ruff() -> Check {
     Check::file("ruff", "ruff check {FILE}", &["*.py"])
         .fix("ruff check --fix {FILE}")
-        .fix_order(70)
         .linter_config("ruff.toml", "--config")
         .baseline_config(RUFF_BASELINE_CONFIG)
         .unsupported_configs(RUFF_UNSUPPORTED_CONFIGS)
@@ -463,7 +453,7 @@ fn check_ruff_format() -> Check {
     Check::file("ruff-format", "ruff format --check {FILE}", &["*.py"])
         .bin("ruff")
         .fix("ruff format {FILE}")
-        .fix_order(80)
+        .fix_after("ruff")
         .linter_config("ruff.toml", "--config")
         .baseline_config(RUFF_BASELINE_CONFIG)
         .unsupported_configs(RUFF_UNSUPPORTED_CONFIGS)
@@ -488,7 +478,6 @@ fn check_biome() -> Check {
         &["*.json", "*.jsonc", "*.js", "*.ts", "*.jsx", "*.tsx"],
     )
     .fix("biome check --fix {FILE}")
-    .fix_order(90)
     .baseline_config(BIOME_BASELINE_CONFIG)
     .unsupported_configs(BIOME_UNSUPPORTED_CONFIGS)
     .project_url(BIOME_URL)
@@ -519,7 +508,7 @@ fn check_biome_format() -> Check {
     )
     .bin("biome")
     .fix("biome format --write {FILE}")
-    .fix_order(100)
+    .fix_after("biome")
     .baseline_config(BIOME_BASELINE_CONFIG)
     .unsupported_configs(BIOME_UNSUPPORTED_CONFIGS)
     .project_url(BIOME_URL)
@@ -550,7 +539,6 @@ fn check_cargo_clippy() -> Check {
         &["*.rs"],
     )
     .fix("cargo clippy -q --all-targets --fix --allow-dirty --allow-staged -- -D warnings")
-    .fix_order(110)
     .partial_fix()
     .mise_tool("rust")
     .toolchain_components("clippy")
@@ -567,14 +555,13 @@ fn check_cargo_clippy() -> Check {
         None,
     )
     .desc("Lint Rust code; runs on all .rs files, not just changed")
-    .project_ownership()
     .lang()
 }
 
 fn check_cargo_fmt() -> Check {
     Check::project("cargo-fmt", "cargo fmt -- {CONFIG_ARGS} --check", &["*.rs"])
         .fix("cargo fmt -- {CONFIG_ARGS}")
-        .fix_order(120)
+        .fix_after("cargo-clippy")
         .linter_config("rustfmt.toml", "--config-path")
         .baseline_config(RUSTFMT_BASELINE_CONFIG)
         .unsupported_configs(RUSTFMT_UNSUPPORTED_CONFIGS)
@@ -601,7 +588,6 @@ fn check_cargo_fmt() -> Check {
 fn check_gofmt() -> Check {
     Check::file("gofmt", "gofmt -d {FILE}", &["*.go"])
         .fix("gofmt -w {FILE}")
-        .fix_order(130)
         .mise_tool("go")
         .toolchain()
         .project_url(GOFMT_URL)
@@ -623,7 +609,6 @@ fn check_google_java_format() -> Check {
         &["*.java"],
     )
     .fix("google-java-format -i {FILES}")
-    .fix_order(140)
     .mise_tool("google-java-format")
     .formatter()
     .editorconfig_line_length_off(
@@ -653,7 +638,6 @@ fn check_ktlint() -> Check {
         &["*.kt", "*.kts"],
     )
     .fix("ktlint --format --log-level=error {FILES}")
-    .fix_order(150)
     .full_cmd(
         "ktlint --log-level=error {ROOT}",
         "ktlint --format --log-level=error {ROOT}",
@@ -681,7 +665,6 @@ fn check_dotnet_format() -> Check {
         &["*.cs"],
     )
     .fix("dotnet format --include {RELFILES}")
-    .fix_order(160)
     .full_cmd("dotnet format --verify-no-changes", "dotnet format")
     .bin("dotnet")
     .mise_tool("dotnet")
@@ -708,7 +691,6 @@ fn check_lychee() -> Check {
             Some("Broken links"),
         )
         .desc("Check for broken links")
-        .project_ownership()
         .docs(
             "Orchestrates [lychee](https://lychee.cli.rs/) for link checking. \
             Requires `lychee` in `[tools]`.\n\
@@ -744,7 +726,6 @@ fn check_lychee() -> Check {
 
 fn check_renovate_deps() -> Check {
     Check::native(&renovate_deps::CHECK_TYPE)
-        .fix_order(170)
         .slow()
         .adaptive_relevance(renovate_deps::adaptive_relevance)
         .mise_tool("npm:renovate")
@@ -757,7 +738,6 @@ fn check_renovate_deps() -> Check {
             Some("Dependency update configuration"),
         )
         .desc("Verify Renovate dependency snapshot is up to date")
-        .project_ownership()
         .docs(
             "Verifies `renovate-tracked-deps.json` next to the active Renovate\n\
             config is up to date by running Renovate locally and comparing its\n\
@@ -822,7 +802,6 @@ fn check_license_header() -> Check {
 
 fn check_flint_setup() -> Check {
     Check::native(&flint_setup::CHECK_TYPE)
-        .fix_order(0)
         .activate_unconditionally()
         .patterns(&["mise.toml"])
         .overview(
@@ -832,7 +811,6 @@ fn check_flint_setup() -> Check {
             Some("Flint-managed setup and `mise.toml` layout"),
         )
         .desc("Keep Flint setup current and mise.toml lint tooling canonical")
-        .project_ownership()
         .docs(
             "Checks the repo's Flint-managed setup state and `mise.toml` layout.\n\
             \n\

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -2,7 +2,7 @@ mod checks;
 mod mise;
 mod obsolete;
 mod resolve;
-pub(crate) mod types;
+mod types;
 
 pub use checks::builtin;
 pub use mise::{

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -2,7 +2,7 @@ mod checks;
 mod mise;
 mod obsolete;
 mod resolve;
-mod types;
+pub(crate) mod types;
 
 pub use checks::builtin;
 pub use mise::{

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -133,19 +133,41 @@ fn registry_entries_have_complete_metadata() {
 }
 
 #[test]
-fn fixers_declare_deterministic_serial_order() {
+fn fixer_dependencies_are_valid_and_acyclic() {
     let registry = builtin();
-    let mut orders = HashMap::new();
+    let fixers: Vec<&Check> = registry.iter().filter(|check| check.has_fix()).collect();
 
-    for check in registry.iter().filter(|check| check.has_fix()) {
-        let order = check
-            .fix_order
-            .unwrap_or_else(|| panic!("{} is fix-capable but has no fix order", check.name));
-        assert_eq!(
-            orders.insert(order, check.name),
-            None,
-            "fix order {order} is shared by multiple checks"
+    for check in &fixers {
+        for dependency in &check.fix_after {
+            assert_ne!(check.name, *dependency, "{} depends on itself", check.name);
+            assert!(
+                fixers.iter().any(|candidate| candidate.name == *dependency),
+                "{} must run after unknown or non-fix-capable check {}",
+                check.name,
+                dependency
+            );
+        }
+    }
+
+    let mut remaining = fixers;
+    while !remaining.is_empty() {
+        let next = remaining.iter().position(|check| {
+            check.fix_after.iter().all(|dependency| {
+                !remaining
+                    .iter()
+                    .any(|candidate| candidate.name == *dependency)
+            })
+        });
+        assert!(
+            next.is_some(),
+            "cyclic fixer ordering involving: {}",
+            remaining
+                .iter()
+                .map(|check| check.name)
+                .collect::<Vec<_>>()
+                .join(", ")
         );
+        remaining.remove(next.unwrap());
     }
 }
 
@@ -322,19 +344,10 @@ fn test_case_groups_match_registered_checks() {
     );
 }
 
-/// Guardrail: two different fixer tools should not claim the same declared file
-/// pattern. Overlap between checks from the same underlying tool is still
-/// allowed for now (e.g. `biome` + `biome-format`, `ruff` + `ruff-format`)
-/// because those pairs are intentionally split into lint and format modes.
+/// Guardrail: two fixers may claim the same declared file pattern only when
+/// their required precedence is explicit in registry metadata.
 #[test]
 fn competing_fixers_must_not_share_declared_patterns() {
-    const ALLOWED_OVERLAPS: &[(&str, &str)] = &[
-        // markdownlint enforces rules; prettier canonicalizes formatting.
-        ("markdownlint-cli2", "prettier"),
-        // clippy and rustfmt both fix Rust files, but serve distinct purposes.
-        ("cargo-clippy", "cargo-fmt"),
-    ];
-
     let registry = builtin();
     let fixers: Vec<&Check> = registry
         .iter()
@@ -344,15 +357,7 @@ fn competing_fixers_must_not_share_declared_patterns() {
     let mut conflicts = vec![];
     for (i, left) in fixers.iter().enumerate() {
         for right in fixers.iter().skip(i + 1) {
-            if left.bin_name == right.bin_name {
-                continue;
-            }
-            let pair = if left.name < right.name {
-                (left.name, right.name)
-            } else {
-                (right.name, left.name)
-            };
-            if ALLOWED_OVERLAPS.contains(&pair) {
+            if left.fix_after.contains(&right.name) || right.fix_after.contains(&left.name) {
                 continue;
             }
 

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -101,6 +101,55 @@ fn registry_tool_key_migrations_are_unique_and_have_targets() {
 }
 
 #[test]
+fn registry_entries_have_complete_metadata() {
+    for check in builtin() {
+        assert!(
+            !check.desc.is_empty(),
+            "{} is missing a description",
+            check.name
+        );
+
+        if check.uses_binary() {
+            assert!(
+                check.install_key().is_some() || check.activate_unconditionally,
+                "{} uses a binary but has no install key",
+                check.name
+            );
+            assert!(
+                check.project_url.is_some(),
+                "{} uses a binary but has no upstream project URL",
+                check.name
+            );
+        }
+
+        if check.linter_config.is_some() {
+            assert!(
+                check.config_doc_url.is_some(),
+                "{} has a config file but no config documentation URL",
+                check.name
+            );
+        }
+    }
+}
+
+#[test]
+fn fixers_declare_deterministic_serial_order() {
+    let registry = builtin();
+    let mut orders = HashMap::new();
+
+    for check in registry.iter().filter(|check| check.has_fix()) {
+        let order = check
+            .fix_order
+            .unwrap_or_else(|| panic!("{} is fix-capable but has no fix order", check.name));
+        assert_eq!(
+            orders.insert(order, check.name),
+            None,
+            "fix order {order} is shared by multiple checks"
+        );
+    }
+}
+
+#[test]
 fn rumdl_batches_matching_files() {
     let check = builtin()
         .into_iter()

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -40,33 +40,6 @@ pub enum Category {
     Slow,
 }
 
-/// The kind of responsibility a check has when multiple checks inspect a file.
-///
-/// This is deliberately separate from [`Scope`]: a file-scoped check can still
-/// be semantic, and a project-scoped check can still be a generic validator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Ownership {
-    /// General syntax, spelling, or style validation.
-    Generic,
-    /// The check owns formatting for the files it matches.
-    Formatter,
-    /// Domain-specific policy or security validation.
-    Semantic,
-    /// Repository-wide or build-graph-oriented validation.
-    Project,
-}
-
-impl Ownership {
-    pub fn name(self) -> &'static str {
-        match self {
-            Self::Generic => "generic",
-            Self::Formatter => "formatter",
-            Self::Semantic => "semantic",
-            Self::Project => "project",
-        }
-    }
-}
-
 impl Category {
     pub fn name(self) -> &'static str {
         match self {
@@ -578,8 +551,6 @@ pub struct Check {
     pub baseline_triggers: &'static [ConfigFile],
     /// This check is a formatter — it owns certain file types for formatting purposes.
     pub is_formatter: bool,
-    /// Broad responsibility category used to document legitimate overlap.
-    pub ownership: Ownership,
     /// Skip files owned by active formatters (used by ec to avoid double-checking).
     pub defers_to_formatters: bool,
     /// Optional `.editorconfig` line-length carve-out owned by this check.
@@ -603,9 +574,8 @@ pub struct Check {
     /// Extra generated workflow setup needed when this check is selected by `flint init`.
     pub workflow_setup: Option<WorkflowSetup>,
     pub fix_behavior: FixBehavior,
-    /// Deterministic order for fix-capable checks. Checks that can touch the
-    /// same file must declare an explicit order; fixes are still run serially.
-    pub fix_order: Option<u16>,
+    /// Fixers that must complete before this check runs in fix mode.
+    pub fix_after: Vec<&'static str>,
     pub kind: CheckKind,
     /// Plain-text description of what the check does — shown in `flint linters` and the README table.
     pub desc: &'static str,
@@ -723,7 +693,6 @@ impl Check {
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
-            ownership: Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -739,7 +708,7 @@ impl Check {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
-            fix_order: None,
+            fix_after: vec![],
             desc: "",
             project_url: None,
             config_doc_url: None,
@@ -779,7 +748,6 @@ impl Check {
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
-            ownership: Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -788,7 +756,7 @@ impl Check {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
-            fix_order: None,
+            fix_after: vec![],
             kind: CheckKind::Native(NativeCheckRef::new(native)),
             desc: "",
             project_url: None,
@@ -871,25 +839,12 @@ impl Check {
     /// Mark as a formatter — files it owns are excluded from ec when both are active.
     pub fn formatter(mut self) -> Self {
         self.is_formatter = true;
-        self.ownership = Ownership::Formatter;
         self
     }
 
-    /// Mark this check as a domain-specific policy or security check.
-    pub fn semantic(mut self) -> Self {
-        self.ownership = Ownership::Semantic;
-        self
-    }
-
-    /// Mark this check as a repository-wide/project check.
-    pub fn project_ownership(mut self) -> Self {
-        self.ownership = Ownership::Project;
-        self
-    }
-
-    /// Set the explicit serial fix order for this check.
-    pub fn fix_order(mut self, order: u16) -> Self {
-        self.fix_order = Some(order);
+    /// Run this fixer after the named fixer when both are active.
+    pub fn fix_after(mut self, check: &'static str) -> Self {
+        self.fix_after.push(check);
         self
     }
 

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -40,6 +40,44 @@ pub enum Category {
     Slow,
 }
 
+/// The kind of responsibility a check has when multiple checks inspect a file.
+///
+/// This is deliberately separate from [`Scope`]: a file-scoped check can still
+/// be semantic, and a project-scoped check can still be a generic validator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Ownership {
+    /// General syntax, spelling, or style validation.
+    Generic,
+    /// The check owns formatting for the files it matches.
+    Formatter,
+    /// Domain-specific policy or security validation.
+    Semantic,
+    /// Repository-wide or build-graph-oriented validation.
+    Project,
+}
+
+impl Ownership {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Generic => "generic",
+            Self::Formatter => "formatter",
+            Self::Semantic => "semantic",
+            Self::Project => "project",
+        }
+    }
+}
+
+impl Category {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Lang => "lang",
+            Self::Style => "style",
+            Self::Default => "default",
+            Self::Slow => "slow",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum OverviewSection {
     Languages,
@@ -527,12 +565,21 @@ pub struct Check {
     pub status_hook: Option<StatusHook>,
     /// Optional output normalizer used for non-verbose failing process runs.
     pub nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
+    /// Output markers that make an otherwise successful process invocation fail.
+    ///
+    /// Some tools are configured to report violations with a zero exit status
+    /// (for example, Checkstyle with warning severity), while their host build
+    /// plugin treats that output as a failure. These markers preserve that
+    /// repository-level contract in Flint.
+    pub failure_output_patterns: &'static [&'static str],
     /// Optional hint appended when a known toolchain component is missing.
     pub missing_component_hint: Option<MissingComponentHint>,
     /// Additional config-like files that trigger an all-files baseline run when changed.
     pub baseline_triggers: &'static [ConfigFile],
     /// This check is a formatter — it owns certain file types for formatting purposes.
     pub is_formatter: bool,
+    /// Broad responsibility category used to document legitimate overlap.
+    pub ownership: Ownership,
     /// Skip files owned by active formatters (used by ec to avoid double-checking).
     pub defers_to_formatters: bool,
     /// Optional `.editorconfig` line-length carve-out owned by this check.
@@ -556,6 +603,9 @@ pub struct Check {
     /// Extra generated workflow setup needed when this check is selected by `flint init`.
     pub workflow_setup: Option<WorkflowSetup>,
     pub fix_behavior: FixBehavior,
+    /// Deterministic order for fix-capable checks. Checks that can touch the
+    /// same file must declare an explicit order; fixes are still run serially.
+    pub fix_order: Option<u16>,
     pub kind: CheckKind,
     /// Plain-text description of what the check does — shown in `flint linters` and the README table.
     pub desc: &'static str,
@@ -669,9 +719,11 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
+            ownership: Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -687,6 +739,7 @@ impl Check {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
+            fix_order: None,
             desc: "",
             project_url: None,
             config_doc_url: None,
@@ -722,9 +775,11 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
+            ownership: Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -733,6 +788,7 @@ impl Check {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
+            fix_order: None,
             kind: CheckKind::Native(NativeCheckRef::new(native)),
             desc: "",
             project_url: None,
@@ -815,6 +871,25 @@ impl Check {
     /// Mark as a formatter — files it owns are excluded from ec when both are active.
     pub fn formatter(mut self) -> Self {
         self.is_formatter = true;
+        self.ownership = Ownership::Formatter;
+        self
+    }
+
+    /// Mark this check as a domain-specific policy or security check.
+    pub fn semantic(mut self) -> Self {
+        self.ownership = Ownership::Semantic;
+        self
+    }
+
+    /// Mark this check as a repository-wide/project check.
+    pub fn project_ownership(mut self) -> Self {
+        self.ownership = Ownership::Project;
+        self
+    }
+
+    /// Set the explicit serial fix order for this check.
+    pub fn fix_order(mut self, order: u16) -> Self {
+        self.fix_order = Some(order);
         self
     }
 
@@ -992,6 +1067,11 @@ impl Check {
 
     pub fn nonverbose_failure_output(mut self, hook: NonverboseFailureOutputHook) -> Self {
         self.nonverbose_failure_output = Some(hook);
+        self
+    }
+
+    pub fn failure_output_patterns(mut self, patterns: &'static [&'static str]) -> Self {
+        self.failure_output_patterns = patterns;
         self
     }
 

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -527,13 +527,6 @@ pub struct Check {
     pub status_hook: Option<StatusHook>,
     /// Optional output normalizer used for non-verbose failing process runs.
     pub nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
-    /// Output markers that make an otherwise successful process invocation fail.
-    ///
-    /// Some tools are configured to report violations with a zero exit status
-    /// (for example, Checkstyle with warning severity), while their host build
-    /// plugin treats that output as a failure. These markers preserve that
-    /// repository-level contract in Flint.
-    pub failure_output_patterns: &'static [&'static str],
     /// Optional hint appended when a known toolchain component is missing.
     pub missing_component_hint: Option<MissingComponentHint>,
     /// Additional config-like files that trigger an all-files baseline run when changed.
@@ -678,7 +671,6 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
-            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -733,7 +725,6 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
-            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -1011,11 +1002,6 @@ impl Check {
 
     pub fn nonverbose_failure_output(mut self, hook: NonverboseFailureOutputHook) -> Self {
         self.nonverbose_failure_output = Some(hook);
-        self
-    }
-
-    pub fn failure_output_patterns(mut self, patterns: &'static [&'static str]) -> Self {
-        self.failure_output_patterns = patterns;
         self
     }
 

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -40,17 +40,6 @@ pub enum Category {
     Slow,
 }
 
-impl Category {
-    pub fn name(self) -> &'static str {
-        match self {
-            Self::Lang => "lang",
-            Self::Style => "style",
-            Self::Default => "default",
-            Self::Slow => "slow",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum OverviewSection {
     Languages,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -163,13 +163,11 @@ pub async fn run(
         short,
         time,
     } = opts;
-    let mut ordered_checks = checks.to_vec();
-    if fix {
-        // Fix-capable checks are serialized below. An explicit order makes the
-        // precedence visible in the registry instead of relying on incidental
-        // registry construction order when checks overlap.
-        ordered_checks.sort_by_key(|check| check.fix_order.unwrap_or(u16::MAX));
-    }
+    let ordered_checks = if fix {
+        order_checks_for_fix(checks)?
+    } else {
+        checks.to_vec()
+    };
 
     let prepared: Vec<PreparedCheck> = ordered_checks
         .iter()
@@ -225,6 +223,31 @@ pub async fn run(
     }
 
     Ok(collected)
+}
+
+fn order_checks_for_fix<'a>(checks: &[&'a Check]) -> Result<Vec<&'a Check>> {
+    let mut remaining = checks.to_vec();
+    let mut ordered = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let Some(index) = remaining.iter().position(|check| {
+            check.fix_after.iter().all(|dependency| {
+                !remaining
+                    .iter()
+                    .any(|candidate| candidate.name == *dependency)
+            })
+        }) else {
+            let names = remaining
+                .iter()
+                .map(|check| check.name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("cyclic fixer ordering involving: {names}");
+        };
+        ordered.push(remaining.remove(index));
+    }
+
+    Ok(ordered)
 }
 
 fn prepare(
@@ -921,7 +944,6 @@ mod tests {
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
-            ownership: crate::registry::types::Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: crate::registry::EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -930,7 +952,7 @@ mod tests {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: crate::registry::FixBehavior::Definitive,
-            fix_order: None,
+            fix_after: vec![],
             kind: CheckKind::Template {
                 check_cmd: "run-it",
                 fix_cmd: "",
@@ -968,6 +990,34 @@ mod tests {
         ));
         assert!(!output_contains_any(b"clean\n", &["[WARN]"]));
         assert!(!output_contains_any(b"anything\n", &[""]));
+    }
+
+    #[test]
+    fn fix_order_follows_declared_dependencies() {
+        let mut first = project_check(&[]);
+        first.name = "first";
+        let mut second = project_check(&[]);
+        second.name = "second";
+        second.fix_after.push("first");
+
+        let ordered = order_checks_for_fix(&[&second, &first]).unwrap();
+        assert_eq!(
+            ordered.iter().map(|check| check.name).collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+    }
+
+    #[test]
+    fn fix_order_rejects_cycles() {
+        let mut first = project_check(&[]);
+        first.name = "first";
+        first.fix_after.push("second");
+        let mut second = project_check(&[]);
+        second.name = "second";
+        second.fix_after.push("first");
+
+        let error = order_checks_for_fix(&[&first, &second]).unwrap_err();
+        assert!(error.to_string().contains("cyclic fixer ordering"));
     }
 
     fn file_list(paths: &[&str]) -> FileList {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -47,6 +47,7 @@ struct InvocationOutputPolicy<'a> {
     env: &'a [(&'static str, &'static str)],
     nonverbose_filter_prefixes: &'a [&'static str],
     stderr_filter_prefixes: &'a [&'static str],
+    failure_output_patterns: &'a [&'static str],
 }
 
 /// A check with all inputs pre-resolved, ready to execute without borrowing
@@ -60,6 +61,7 @@ enum PreparedCheck {
         env: &'static [(&'static str, &'static str)],
         nonverbose_filter_prefixes: &'static [&'static str],
         stderr_filter_prefixes: &'static [&'static str],
+        failure_output_patterns: &'static [&'static str],
         nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
         missing_component_hint: Option<MissingComponentHint>,
     },
@@ -85,6 +87,7 @@ impl PreparedCheck {
                 env,
                 nonverbose_filter_prefixes,
                 stderr_filter_prefixes,
+                failure_output_patterns,
                 nonverbose_failure_output,
                 missing_component_hint,
                 ..
@@ -107,6 +110,7 @@ impl PreparedCheck {
                             nonverbose_filter_prefixes
                         },
                         stderr_filter_prefixes: if verbose { &[] } else { stderr_filter_prefixes },
+                        failure_output_patterns,
                     },
                     nonverbose_failure_output,
                     missing_component_hint,
@@ -159,7 +163,15 @@ pub async fn run(
         short,
         time,
     } = opts;
-    let prepared: Vec<PreparedCheck> = checks
+    let mut ordered_checks = checks.to_vec();
+    if fix {
+        // Fix-capable checks are serialized below. An explicit order makes the
+        // precedence visible in the registry instead of relying on incidental
+        // registry construction order when checks overlap.
+        ordered_checks.sort_by_key(|check| check.fix_order.unwrap_or(u16::MAX));
+    }
+
+    let prepared: Vec<PreparedCheck> = ordered_checks
         .iter()
         .filter_map(|&check| {
             prepare(
@@ -247,6 +259,7 @@ fn prepare(
                 env: check.env,
                 nonverbose_filter_prefixes: check.nonverbose_filter_prefixes,
                 stderr_filter_prefixes: check.stderr_filter_prefixes,
+                failure_output_patterns: check.failure_output_patterns,
                 nonverbose_failure_output: check.nonverbose_failure_output,
                 missing_component_hint: check.missing_component_hint,
             })
@@ -563,6 +576,9 @@ async fn run_invocations(
         let result = cmd.output().await;
         match result {
             Ok(out) => {
+                let output_policy_failed =
+                    output_contains_any(&out.stdout, output_policy.failure_output_patterns)
+                        || output_contains_any(&out.stderr, output_policy.failure_output_patterns);
                 if output_policy.nonverbose
                     && !out.status.success()
                     && let Some(normalize) = nonverbose_failure_output
@@ -603,7 +619,7 @@ async fn run_invocations(
                         combined_stderr.extend_from_slice(&stderr);
                     }
                 }
-                if !out.status.success() {
+                if !out.status.success() || output_policy_failed {
                     all_ok = false;
                 }
             }
@@ -623,6 +639,17 @@ async fn run_invocations(
         stderr: combined_stderr,
         setup_outcome: None,
     }
+}
+
+fn output_contains_any(output: &[u8], patterns: &[&str]) -> bool {
+    patterns
+        .iter()
+        .filter(|pattern| !pattern.is_empty())
+        .any(|pattern| {
+            output
+                .windows(pattern.len())
+                .any(|window| window == pattern.as_bytes())
+        })
 }
 
 fn filter_stderr_lines(stderr: &[u8], prefixes: &[&str]) -> Vec<u8> {
@@ -890,9 +917,11 @@ mod tests {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
+            ownership: crate::registry::types::Ownership::Generic,
             defers_to_formatters: false,
             editorconfig_line_length_policy: crate::registry::EditorconfigLineLengthPolicy::Default,
             activate_unconditionally: false,
@@ -901,6 +930,7 @@ mod tests {
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: crate::registry::FixBehavior::Definitive,
+            fix_order: None,
             kind: CheckKind::Template {
                 check_cmd: "run-it",
                 fix_cmd: "",
@@ -927,6 +957,17 @@ mod tests {
             },
             ..project_check(patterns)
         }
+    }
+
+    #[test]
+    fn failure_output_patterns_match_stdout_and_stderr() {
+        assert!(output_contains_any(b"[WARN] violation\n", &["[WARN]"]));
+        assert!(output_contains_any(
+            b"error: [WARN] violation\n",
+            &["[WARN]"]
+        ));
+        assert!(!output_contains_any(b"clean\n", &["[WARN]"]));
+        assert!(!output_contains_any(b"anything\n", &[""]));
     }
 
     fn file_list(paths: &[&str]) -> FileList {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -47,7 +47,6 @@ struct InvocationOutputPolicy<'a> {
     env: &'a [(&'static str, &'static str)],
     nonverbose_filter_prefixes: &'a [&'static str],
     stderr_filter_prefixes: &'a [&'static str],
-    failure_output_patterns: &'a [&'static str],
 }
 
 /// A check with all inputs pre-resolved, ready to execute without borrowing
@@ -61,7 +60,6 @@ enum PreparedCheck {
         env: &'static [(&'static str, &'static str)],
         nonverbose_filter_prefixes: &'static [&'static str],
         stderr_filter_prefixes: &'static [&'static str],
-        failure_output_patterns: &'static [&'static str],
         nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
         missing_component_hint: Option<MissingComponentHint>,
     },
@@ -87,7 +85,6 @@ impl PreparedCheck {
                 env,
                 nonverbose_filter_prefixes,
                 stderr_filter_prefixes,
-                failure_output_patterns,
                 nonverbose_failure_output,
                 missing_component_hint,
                 ..
@@ -110,7 +107,6 @@ impl PreparedCheck {
                             nonverbose_filter_prefixes
                         },
                         stderr_filter_prefixes: if verbose { &[] } else { stderr_filter_prefixes },
-                        failure_output_patterns,
                     },
                     nonverbose_failure_output,
                     missing_component_hint,
@@ -282,7 +278,6 @@ fn prepare(
                 env: check.env,
                 nonverbose_filter_prefixes: check.nonverbose_filter_prefixes,
                 stderr_filter_prefixes: check.stderr_filter_prefixes,
-                failure_output_patterns: check.failure_output_patterns,
                 nonverbose_failure_output: check.nonverbose_failure_output,
                 missing_component_hint: check.missing_component_hint,
             })
@@ -599,9 +594,6 @@ async fn run_invocations(
         let result = cmd.output().await;
         match result {
             Ok(out) => {
-                let output_policy_failed =
-                    output_contains_any(&out.stdout, output_policy.failure_output_patterns)
-                        || output_contains_any(&out.stderr, output_policy.failure_output_patterns);
                 if output_policy.nonverbose
                     && !out.status.success()
                     && let Some(normalize) = nonverbose_failure_output
@@ -642,7 +634,7 @@ async fn run_invocations(
                         combined_stderr.extend_from_slice(&stderr);
                     }
                 }
-                if !out.status.success() || output_policy_failed {
+                if !out.status.success() {
                     all_ok = false;
                 }
             }
@@ -662,17 +654,6 @@ async fn run_invocations(
         stderr: combined_stderr,
         setup_outcome: None,
     }
-}
-
-fn output_contains_any(output: &[u8], patterns: &[&str]) -> bool {
-    patterns
-        .iter()
-        .filter(|pattern| !pattern.is_empty())
-        .any(|pattern| {
-            output
-                .windows(pattern.len())
-                .any(|window| window == pattern.as_bytes())
-        })
 }
 
 fn filter_stderr_lines(stderr: &[u8], prefixes: &[&str]) -> Vec<u8> {
@@ -940,7 +921,6 @@ mod tests {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
-            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -979,17 +959,6 @@ mod tests {
             },
             ..project_check(patterns)
         }
-    }
-
-    #[test]
-    fn failure_output_patterns_match_stdout_and_stderr() {
-        assert!(output_contains_any(b"[WARN] violation\n", &["[WARN]"]));
-        assert!(output_contains_any(
-            b"error: [WARN] violation\n",
-            &["[WARN]"]
-        ));
-        assert!(!output_contains_any(b"clean\n", &["[WARN]"]));
-        assert!(!output_contains_any(b"anything\n", &[""]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add registry ownership and category metadata
- declare deterministic fixer ordering and output contracts
- keep read-only checks parallel while serializing fix execution
- add tests guarding metadata completeness and fixer ordering

Stacked on the ADR-only PR.

## Validation

- `cargo fmt --all -- --check`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
- `mise exec -- cargo test --bin flint` (281 passed; local test used a temporary no-op `dotnet` executable)
- `mise run lint:fix`
