### PR TITLE
feat: improve Flint init and setup migrations

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 
 ```text
 flint run [OPTIONS] [LINTERS...]
-flint init
+flint init [OPTIONS]
 flint hook install
 flint linters
 flint version
@@ -181,6 +181,17 @@ flint run --fix rumdl             # fix only Markdown issues
 
 ## `flint init`
 
+To add or refresh only selected checks without removing unrelated Flint setup,
+use `--only`:
+
+```bash
+flint init --only rumdl
+```
+
+Focused init preserves unrelated tools and configuration, rejects unknown
+check names, and remains idempotent. The existing no-argument and profile-based
+forms continue to discover and reconcile the repository's complete Flint setup.
+
 `flint init` pins Flint itself in `mise.toml` so every contributor uses the same
 lint binary. For unreleased consumer validation, pass an explicit git revision:
 
@@ -234,3 +245,7 @@ cargo-fmt       cargo-fmt       missing    fast   *.rs
 renovate-deps   renovate        installed  fast
 ...
 ```
+
+Use `--json` for complete registry and setup metadata, including the declared
+version, canonical install key, config locations, upstream links, fix behavior,
+formatter relationships, and baseline triggers.

--- a/src/init/detection.rs
+++ b/src/init/detection.rs
@@ -159,3 +159,40 @@ pub(super) fn build_linter_groups<'a>(
     groups.sort_by_key(|g| g.checks.first().map_or(g.key, |c| c.name));
     groups
 }
+
+/// Builds groups for explicitly requested checks, even when their file patterns
+/// are not present or their tool is not currently installed.
+pub(super) fn build_explicit_linter_groups<'a>(
+    checks: &[&'a Check],
+    current_tool_keys: &HashSet<String>,
+    current_content: &str,
+) -> Vec<LinterGroup<'a>> {
+    let mut by_key: HashMap<&'static str, Vec<&'a Check>> = HashMap::new();
+    for check in checks {
+        let Some(key) = install_key(check) else {
+            continue;
+        };
+        by_key.entry(key).or_default().push(check);
+    }
+
+    let mut groups: Vec<LinterGroup<'a>> = by_key
+        .into_iter()
+        .map(|(key, mut checks)| {
+            checks.sort_by_key(|check| check.name);
+            let installed = current_tool_keys.contains(key);
+            let current_components = installed
+                .then(|| get_entry_components(current_content, key))
+                .flatten();
+            LinterGroup {
+                key,
+                check_selected: vec![true; checks.len()],
+                checks,
+                installed,
+                current_components,
+            }
+        })
+        .collect();
+
+    groups.sort_by_key(|group| group.checks.first().map_or(group.key, |check| check.name));
+    groups
+}

--- a/src/init/generation.rs
+++ b/src/init/generation.rs
@@ -6,7 +6,8 @@ use std::process::Command;
 use super::LinterGroup;
 
 pub(super) use super::mise_tools::{
-    apply_changes, ensure_flint_self_pin, ensure_node_for_npm, remove_tool_keys,
+    apply_changes, ensure_flint_self_pin, ensure_flint_self_pin_additive, ensure_node_for_npm,
+    remove_tool_keys,
 };
 pub(crate) use super::mise_tools::{
     needs_node_for_npm, normalize_tools_section, replace_obsolete_keys,

--- a/src/init/migrations.rs
+++ b/src/init/migrations.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
-use std::collections::HashSet;
+use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::linters::typos::MigrationResult as TyposMigrationResult;
@@ -30,6 +30,18 @@ struct MigrationInputs {
 }
 
 impl RepoMigrationSummary {
+    pub(super) fn noop() -> Self {
+        Self {
+            replaced_obsolete: vec![],
+            removed_unsupported: vec![],
+            node_added: false,
+            legacy_files_removed: vec![],
+            stale_md013_comments_removed: vec![],
+            stale_editorconfig_checker_comments_removed: vec![],
+            typos_migration: TyposMigrationResult::default(),
+        }
+    }
+
     pub(super) fn is_noop(&self) -> bool {
         self.replaced_obsolete.is_empty()
             && self.removed_unsupported.is_empty()
@@ -239,7 +251,8 @@ fn apply_repo_migrations_with_keys(
     unsupported_keys: &[(&'static str, &'static str)],
     include_repo_cleanup: bool,
 ) -> Result<RepoMigrationSummary> {
-    let replaced_obsolete = generation::replace_obsolete_keys(project_root, obsolete_keys)?;
+    let replaced_obsolete =
+        replace_obsolete_keys_preserving_decorations(project_root, obsolete_keys)?;
     let removed_unsupported = remove_tool_keys(
         project_root,
         &unsupported_keys
@@ -278,6 +291,133 @@ fn apply_repo_migrations_with_keys(
     })
 }
 
+#[derive(Default)]
+struct ToolDecorations {
+    key_prefix: Option<String>,
+    value_suffix: Option<String>,
+}
+
+/// Runs the mise key conversion and restores comments attached to the old key.
+///
+/// `toml_edit::Table::remove` returns the value item, but not the key's
+/// decoration. The subsequent `Table::insert` therefore preserves an inline
+/// value comment in most cases while dropping a reviewer-facing comment above
+/// the key. Capture both sides before the conversion and restore them on the
+/// replacement key. This intentionally stays scoped to obsolete-key
+/// conversions; unrelated setup rewrites remain owned by their existing
+/// migration helpers.
+fn replace_obsolete_keys_preserving_decorations(
+    project_root: &Path,
+    obsolete: &[(&str, &str)],
+) -> Result<Vec<(String, String)>> {
+    let path = project_root.join("mise.toml");
+    let before = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return generation::replace_obsolete_keys(project_root, obsolete);
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+
+    let keys = obsolete
+        .iter()
+        .flat_map(|(old_key, new_key)| [*old_key, *new_key])
+        .collect::<Vec<_>>();
+    let decorations = capture_tool_decorations(&before, &keys);
+    let replaced = generation::replace_obsolete_keys(project_root, obsolete)?;
+    if replaced.is_empty() || decorations.is_empty() {
+        return Ok(replaced);
+    }
+
+    restore_tool_decorations(&path, &decorations, &replaced)?;
+    Ok(replaced)
+}
+
+fn capture_tool_decorations(content: &str, keys: &[&str]) -> HashMap<String, ToolDecorations> {
+    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+        return HashMap::new();
+    };
+    let Some(tools) = doc.get("tools").and_then(|item| item.as_table()) else {
+        return HashMap::new();
+    };
+
+    keys.iter()
+        .filter_map(|key| {
+            let item = tools.get(key)?;
+            let key_prefix = tools
+                .key(key)
+                .and_then(|key| key.leaf_decor().prefix())
+                .and_then(|raw| raw_string_text(raw, content));
+            let value_suffix = item
+                .as_value()
+                .and_then(|value| value.decor().suffix())
+                .and_then(|raw| raw_string_text(raw, content));
+            Some((
+                (*key).to_string(),
+                ToolDecorations {
+                    key_prefix,
+                    value_suffix,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn raw_string_text(raw: &toml_edit::RawString, source: &str) -> Option<String> {
+    raw.as_str().map(str::to_string).or_else(|| {
+        raw.span()
+            .and_then(|span| source.get(span).map(str::to_string))
+    })
+}
+
+fn restore_tool_decorations(
+    path: &Path,
+    decorations: &HashMap<String, ToolDecorations>,
+    replaced: &[(String, String)],
+) -> Result<()> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {} after migration", path.display()))?;
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse {} after migration", path.display()))?;
+    let Some(tools) = doc.get_mut("tools").and_then(|item| item.as_table_mut()) else {
+        return Ok(());
+    };
+
+    let mut changed = false;
+    for (old_key, new_key) in replaced {
+        let Some(source) = decorations.get(old_key) else {
+            continue;
+        };
+        {
+            let Some(mut key) = tools.key_mut(new_key) else {
+                continue;
+            };
+            if let Some(prefix) = source.key_prefix.as_deref()
+                && prefix.contains('#')
+            {
+                key.leaf_decor_mut().set_prefix(prefix);
+                changed = true;
+            }
+        }
+        if let Some(suffix) = source.value_suffix.as_deref()
+            && suffix.contains('#')
+            && let Some(value) = tools.get_mut(new_key).and_then(|item| item.as_value_mut())
+        {
+            value.decor_mut().set_suffix(suffix);
+            changed = true;
+        }
+    }
+
+    if changed {
+        std::fs::write(path, doc.to_string())
+            .with_context(|| format!("failed to write {} after migration", path.display()))?;
+    }
+    Ok(())
+}
+
 fn legacy_markdownlint_stack_active(tool_keys: &HashSet<String>) -> bool {
     const MARKDOWNLINT_STACK_KEYS: &[&str] = &[
         "npm:markdownlint-cli",
@@ -297,4 +437,26 @@ fn delegated_patterns_include(
     delegated_sections
         .iter()
         .any(|(patterns, _)| patterns.contains(&needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn obsolete_key_conversion_restores_key_and_inline_comments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("mise.toml");
+        let before = "[tools]\n# Keep this pin until the replacement is verified.\nold = \"1.2.3\" # tracked by release engineering\n";
+        std::fs::write(&path, before).unwrap();
+
+        let replaced =
+            replace_obsolete_keys_preserving_decorations(temp_dir.path(), &[("old", "new")])
+                .unwrap();
+        assert_eq!(replaced, [("old".to_string(), "new".to_string())]);
+
+        let migrated = std::fs::read_to_string(path).unwrap();
+        assert!(migrated.contains("# Keep this pin until the replacement is verified."));
+        assert!(migrated.contains("# tracked by release engineering"));
+    }
 }

--- a/src/init/mise_tools.rs
+++ b/src/init/mise_tools.rs
@@ -83,6 +83,27 @@ pub(crate) fn ensure_flint_self_pin(project_root: &Path, flint_rev: Option<&str>
     ensure_flint_self_pin_with(project_root, flint_rev, run_mise_use)
 }
 
+/// Adds Flint's self-pin only when no Flint tool key exists yet.
+///
+/// Focused `init --only` runs are additive: an existing release or prerelease
+/// pin is left untouched rather than being replaced by the requested backend.
+pub(crate) fn ensure_flint_self_pin_additive(
+    project_root: &Path,
+    flint_rev: Option<&str>,
+) -> Result<bool> {
+    let path = project_root.join("mise.toml");
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let has_pin = content
+        .parse::<toml_edit::DocumentMut>()
+        .ok()
+        .and_then(|doc| doc.get("tools").and_then(|tools| tools.as_table()).cloned())
+        .is_some_and(|tools| tools.iter().any(|(key, _)| is_flint_tool_key(key)));
+    if has_pin {
+        return Ok(false);
+    }
+    ensure_flint_self_pin(project_root, flint_rev)
+}
+
 fn ensure_flint_self_pin_with(
     project_root: &Path,
     flint_rev: Option<&str>,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 #[cfg(test)]
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -18,12 +18,13 @@ use config_files::{
     disable_editorconfig_line_length_for_patterns, generate_editorconfig, generate_flint_toml,
 };
 use detection::{
-    build_linter_groups, detect_obsolete_keys, detect_present_patterns, parse_tool_keys,
+    build_explicit_linter_groups, build_linter_groups, detect_obsolete_keys,
+    detect_present_patterns, parse_tool_keys,
 };
 use generation::{
-    apply_changes, detect_base_branch, ensure_flint_self_pin, ensure_node_for_npm,
-    get_existing_config_dir, has_slow_selected, normalize_tools_section, prompt_config_dir,
-    remove_tool_keys,
+    apply_changes, detect_base_branch, ensure_flint_self_pin, ensure_flint_self_pin_additive,
+    ensure_node_for_npm, get_existing_config_dir, has_slow_selected, normalize_tools_section,
+    prompt_config_dir, remove_tool_keys,
 };
 use migrations::{
     apply_repo_migrations, selected_editorconfig_cleanup_sections,
@@ -66,6 +67,84 @@ fn profile_to_categories(profile: Profile) -> HashSet<Category> {
         ]
         .into(),
     }
+}
+
+fn resolve_only_checks<'a>(registry: &'a [Check], names: &[String]) -> Result<Vec<&'a Check>> {
+    let requested: HashSet<&str> = names.iter().map(String::as_str).collect();
+    let unknown: Vec<&str> = names
+        .iter()
+        .filter_map(|name| {
+            (!registry.iter().any(|check| check.name == name)).then_some(name.as_str())
+        })
+        .collect();
+    if !unknown.is_empty() {
+        let noun = if unknown.len() == 1 {
+            "check"
+        } else {
+            "checks"
+        };
+        bail!(
+            "flint: unknown {noun}: {}",
+            unknown
+                .iter()
+                .map(|name| format!("{name:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    // Follow registry order rather than CLI order. This keeps shared tool
+    // components and setup hooks deterministic, and naturally de-duplicates
+    // repeated names.
+    Ok(registry
+        .iter()
+        .filter(|check| requested.contains(check.name))
+        .collect())
+}
+
+fn merge_components(current: Option<&str>, required: &str) -> String {
+    let mut components: Vec<&str> = current
+        .into_iter()
+        .flat_map(|components| components.split(','))
+        .map(str::trim)
+        .filter(|component| !component.is_empty())
+        .collect();
+
+    for required_component in required.split(',').map(str::trim) {
+        if !required_component.is_empty() && !components.contains(&required_component) {
+            components.push(required_component);
+        }
+    }
+    components.join(",")
+}
+
+type ToolAdd = (String, Option<String>);
+type ToolUpgrade = (String, String);
+
+fn explicit_tool_changes(groups: &[LinterGroup<'_>]) -> (Vec<ToolAdd>, Vec<ToolUpgrade>) {
+    let mut to_add = vec![];
+    let mut to_upgrade = vec![];
+
+    for group in groups {
+        let Some(required) = group.selected_components() else {
+            if !group.installed {
+                to_add.push((group.key.to_string(), None));
+            }
+            continue;
+        };
+
+        if !group.installed {
+            to_add.push((group.key.to_string(), Some(required)));
+            continue;
+        }
+
+        let merged = merge_components(group.current_components.as_deref(), &required);
+        if group.current_components.as_deref() != Some(merged.as_str()) {
+            to_upgrade.push((group.key.to_string(), merged));
+        }
+    }
+
+    (to_add, to_upgrade)
 }
 
 fn selected_checks<'a>(groups: &'a [LinterGroup<'a>]) -> Vec<&'a Check> {
@@ -222,21 +301,51 @@ pub fn run(
     yes: bool,
     flint_rev: Option<&str>,
 ) -> Result<()> {
+    run_with_only(project_root, profile_arg, &[], yes, flint_rev)
+}
+
+pub fn run_with_only(
+    project_root: &Path,
+    profile_arg: Option<Profile>,
+    only_names: &[String],
+    yes: bool,
+    flint_rev: Option<&str>,
+) -> Result<()> {
+    let registry = builtin();
+    let only_checks = resolve_only_checks(&registry, only_names)?;
+    let only_mode = !only_names.is_empty();
+    if only_mode {
+        let builtins: Vec<&str> = only_checks
+            .iter()
+            .filter(|check| install_key(check).is_none())
+            .map(|check| check.name)
+            .collect();
+        if !builtins.is_empty() {
+            bail!(
+                "flint: --only cannot install built-in or config-only checks: {}",
+                builtins.join(", ")
+            );
+        }
+    }
+
     println!(
         "Tip: flint init detects languages from tracked files (`git ls-files`). \
 Add and stage your source files before running init so the detection is accurate."
     );
     println!();
 
-    let registry = builtin();
-    let mut present_patterns = detect_present_patterns(project_root, &registry)?;
+    let mut present_patterns = if only_mode {
+        HashSet::new()
+    } else {
+        detect_present_patterns(project_root, &registry)?
+    };
 
     // If init will generate `.github/workflows/lint.yml`, treat both the workflow-
     // specific patterns and generic YAML patterns as present so actionlint and
     // ryl get selected in the same run. Without this, init would be
     // non-idempotent: the second run would see the newly-generated workflow and
     // add extra linters then.
-    if !project_root.join(".github/workflows/lint.yml").exists() {
+    if !only_mode && !project_root.join(".github/workflows/lint.yml").exists() {
         present_patterns.insert(".github/workflows/*.yml".to_string());
         present_patterns.insert(".github/workflows/*.yaml".to_string());
         present_patterns.insert("*.yml".to_string());
@@ -245,7 +354,9 @@ Add and stage your source files before running init so the detection is accurate
 
     // Step 1: determine which categories set the initial pre-selection.
     let mut line_length = DEFAULT_LINE_LENGTH;
-    let default_categories: HashSet<Category> = if let Some(profile) = profile_arg {
+    let default_categories: HashSet<Category> = if only_mode {
+        HashSet::new()
+    } else if let Some(profile) = profile_arg {
         profile_to_categories(profile)
     } else if yes {
         profile_to_categories(Profile::Default)
@@ -268,33 +379,43 @@ Add and stage your source files before running init so the detection is accurate
     let known_keys: HashSet<&str> = registry.iter().filter_map(install_key).collect();
     let unsupported_keys: Vec<&str> = crate::registry::unsupported_keys()
         .into_iter()
-        .filter_map(|(old_key, _)| current_tool_keys.contains(old_key).then_some(old_key))
+        .filter_map(|(old_key, _)| {
+            (!only_mode && current_tool_keys.contains(old_key)).then_some(old_key)
+        })
         .collect();
 
     // Step 2: build one group per install key, covering all checks whose files are
     // present in the repo or which are already installed.
-    let mut groups = build_linter_groups(
-        &registry,
-        &present_patterns,
-        &current_tool_keys,
-        &current_content,
-        &default_categories,
-    );
+    let mut groups = if only_mode {
+        build_explicit_linter_groups(&only_checks, &current_tool_keys, &current_content)
+    } else {
+        build_linter_groups(
+            &registry,
+            &present_patterns,
+            &current_tool_keys,
+            &current_content,
+            &default_categories,
+        )
+    };
 
-    if groups.is_empty() {
+    if groups.is_empty() && !only_mode {
         println!("No applicable linters found for this project.");
         return Ok(());
     }
 
     // Step 3: interactive linter table (skipped with --yes).
-    if !yes && !interactive_select_linters(&mut groups)? {
+    if !only_mode && !yes && !interactive_select_linters(&mut groups)? {
         println!("Aborted.");
         return Ok(());
     }
 
     // Detect obsolete tool keys (e.g. github:mvdan/sh → shfmt).
     // These are removed regardless of the interactive selection — keeping them serves no purpose.
-    let obsolete = detect_obsolete_keys(&current_tool_keys);
+    let obsolete = if only_mode {
+        vec![]
+    } else {
+        detect_obsolete_keys(&current_tool_keys)
+    };
     for (old_key, replacement) in &obsolete {
         println!("  removing obsolete linter {old_key} (replaced by {replacement})");
     }
@@ -307,23 +428,29 @@ Add and stage your source files before running init so the detection is accurate
     let mut final_remove: Vec<String> = Vec::new();
     let mut final_upgrade: Vec<(String, String)> = Vec::new();
 
-    for group in &groups {
-        if group.any_selected() {
-            if !group.installed {
-                final_add.push((group.key.to_string(), group.selected_components()));
-            } else {
-                let target = group.selected_components();
-                if target != group.current_components {
-                    // Upgrade: components changed (added, removed, or reordered).
-                    // If the target has no components (e.g. all component-bearing checks
-                    // deselected), treat as a plain-version install via add+remove.
-                    if let Some(comps) = target {
-                        final_upgrade.push((group.key.to_string(), comps));
+    if only_mode {
+        let (add, upgrade) = explicit_tool_changes(&groups);
+        final_add = add;
+        final_upgrade = upgrade;
+    } else {
+        for group in &groups {
+            if group.any_selected() {
+                if !group.installed {
+                    final_add.push((group.key.to_string(), group.selected_components()));
+                } else {
+                    let target = group.selected_components();
+                    if target != group.current_components {
+                        // Upgrade: components changed (added, removed, or reordered).
+                        // If the target has no components (e.g. all component-bearing checks
+                        // deselected), treat as a plain-version install via add+remove.
+                        if let Some(comps) = target {
+                            final_upgrade.push((group.key.to_string(), comps));
+                        }
                     }
                 }
+            } else if group.installed && known_keys.contains(group.key) {
+                final_remove.push(group.key.to_string());
             }
-        } else if group.installed && known_keys.contains(group.key) {
-            final_remove.push(group.key.to_string());
         }
     }
 
@@ -360,7 +487,11 @@ Add and stage your source files before running init so the detection is accurate
             &final_upgrade,
         )?;
     }
-    let flint_pinned = ensure_flint_self_pin(project_root, flint_rev)?;
+    let flint_pinned = if only_mode {
+        ensure_flint_self_pin_additive(project_root, flint_rev)?
+    } else {
+        ensure_flint_self_pin(project_root, flint_rev)?
+    };
     if flint_pinned {
         println!("  pinned flint itself — reproducible lint runs across contributors");
     }
@@ -390,18 +521,26 @@ Add and stage your source files before running init so the detection is accurate
     let editorconfig_line_length_sections =
         selected_editorconfig_line_length_sections(&selected_checks);
     let editorconfig_cleanup_sections = selected_editorconfig_cleanup_sections(&selected_checks);
-    let migration_summary = apply_repo_migrations(
-        project_root,
-        &config_dir_path,
-        &editorconfig_cleanup_sections,
-    )?;
+    let migration_summary = if only_mode {
+        migrations::RepoMigrationSummary::noop()
+    } else {
+        apply_repo_migrations(
+            project_root,
+            &config_dir_path,
+            &editorconfig_cleanup_sections,
+        )?
+    };
     migration_summary.print_messages();
     let editorconfig_generated = generate_editorconfig(project_root, line_length)?;
     let editorconfig_line_length_disabled = disable_editorconfig_line_length_for_patterns(
         project_root,
         &editorconfig_line_length_sections,
     )?;
-    let agent_guidance_changed = ensure_agent_linting_guidance(project_root)?;
+    let agent_guidance_changed = if only_mode {
+        false
+    } else {
+        ensure_agent_linting_guidance(project_root)?
+    };
     if !editorconfig_line_length_disabled.is_empty() {
         println!(
             "  patched <REPO>/.editorconfig — disable max_line_length for {}",

--- a/src/init/tests.rs
+++ b/src/init/tests.rs
@@ -109,6 +109,33 @@ fn all_registry_checks_have_install_key_or_none() {
 }
 
 #[test]
+fn resolve_only_checks_rejects_unknown_names() {
+    let err = resolve_only_checks(&builtin(), &["not-a-check".to_string()]).unwrap_err();
+
+    assert!(err.to_string().contains("unknown check"));
+    assert!(err.to_string().contains("not-a-check"));
+}
+
+#[test]
+fn resolve_only_checks_preserves_registry_order_and_deduplicates() {
+    let registry = builtin();
+    let checks = resolve_only_checks(
+        &registry,
+        &[
+            "typos".to_string(),
+            "rumdl".to_string(),
+            "typos".to_string(),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        checks.iter().map(|check| check.name).collect::<Vec<_>>(),
+        ["rumdl", "typos"]
+    );
+}
+
+#[test]
 fn apply_check_type_init_hooks_runs_shared_hook_once() {
     CHECK_TYPE_INIT_CALLS.store(0, Ordering::SeqCst);
     let first = Check::file("first", "first {FILE}", &["*"]).check_type(&COUNTING_CHECK_TYPE);
@@ -297,6 +324,33 @@ fn init_run_normalizes_node_added_for_existing_npm_tool() {
         node_pos < header_pos && header_pos < renovate_pos,
         "init::run must keep node above the linter block:\n{result}"
     );
+}
+
+#[test]
+fn focused_init_adds_requested_check_without_removing_unrelated_tools() {
+    let dir = tempfile::TempDir::new().unwrap();
+    init_git_repo(dir.path());
+    std::fs::write(
+        dir.path().join("mise.toml"),
+        "[tools]\n\n# Linters\nshellcheck = \"0.11.0\"\n",
+    )
+    .unwrap();
+
+    with_fake_mise(|| {
+        run_with_only(
+            dir.path(),
+            None,
+            &["rumdl".to_string()],
+            true,
+            Some("rev:test"),
+        )
+        .unwrap();
+    });
+
+    let mise = std::fs::read_to_string(dir.path().join("mise.toml")).unwrap();
+    assert!(mise.contains("shellcheck = \"0.11.0\""));
+    assert!(mise.contains("rumdl ="));
+    assert!(dir.path().join(".github/config/.rumdl.toml").exists());
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,12 @@ struct LintersArgs {
 #[derive(Args, Debug)]
 struct InitArgs {
     /// Profile to configure: lang, default, or comprehensive.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, conflicts_with = "only")]
     profile: Option<init::Profile>,
+
+    /// Configure only the named checks. May be followed by multiple check names.
+    #[arg(long, value_name = "CHECK", num_args = 1.., conflicts_with = "profile")]
+    only: Vec<String>,
 
     /// Pin flint itself through cargo at this git revision for prerelease validation.
     #[arg(long, value_name = "REV")]
@@ -161,18 +165,28 @@ async fn main() -> Result<()> {
             let cfg = config::load(&config_dir).unwrap_or_default();
             let mise_tools = registry::read_mise_tools(&project_root);
             if args.json {
-                print_linters_json(&registry);
+                print_linters_json(&registry, &mise_tools, &cfg);
             } else {
                 print_linters(&registry, &mise_tools, &cfg);
             }
         }
         SubCommand::Init(args) => {
-            init::run(
-                &project_root,
-                args.profile,
-                args.yes,
-                args.flint_rev.as_deref(),
-            )?;
+            if args.only.is_empty() {
+                init::run(
+                    &project_root,
+                    args.profile,
+                    args.yes,
+                    args.flint_rev.as_deref(),
+                )?;
+            } else {
+                init::run_with_only(
+                    &project_root,
+                    None,
+                    &args.only,
+                    args.yes,
+                    args.flint_rev.as_deref(),
+                )?;
+            }
         }
         SubCommand::Hook(args) => match args.command {
             HookCommand::Install => hook::install(&project_root)?,
@@ -1004,29 +1018,87 @@ fn normalize_path(path: &Path) -> String {
         .join("/")
 }
 
-fn print_linters_json(registry: &[registry::Check]) {
-    let entries: Vec<serde_json::Value> = registry.iter().map(linter_json).collect();
+fn print_linters_json(
+    registry: &[registry::Check],
+    mise_tools: &HashMap<String, String>,
+    cfg: &config::Config,
+) {
+    let entries: Vec<serde_json::Value> = registry
+        .iter()
+        .map(|check| {
+            let status = linter_status(check, mise_tools, cfg, registry::binary_on_path);
+            let declared_version = check
+                .install_key()
+                .and_then(|key| mise_tools.get(key))
+                .map(String::as_str);
+            linter_json(check, status, declared_version)
+        })
+        .collect();
     println!("{}", serde_json::to_string_pretty(&entries).unwrap());
 }
 
-pub fn linter_json(check: &registry::Check) -> serde_json::Value {
+pub fn linter_json(
+    check: &registry::Check,
+    status: &str,
+    declared_version: Option<&str>,
+) -> serde_json::Value {
     let scope = check.kind.scope_name();
     let patterns: Vec<&str> = check.patterns.to_vec();
     let config_file = check
         .linter_config
         .as_ref()
         .map(LinterConfig::canonical_location);
+    let baseline_config = check
+        .baseline_config
+        .map(|config| config_file_location(&config));
+    let baseline_triggers: Vec<String> = check
+        .baseline_triggers
+        .iter()
+        .map(config_file_location)
+        .collect();
+    let fix_behavior = check.has_fix().then(|| match check.fix_behavior() {
+        FixBehavior::Definitive => "definitive",
+        FixBehavior::PartialNeedsVerify => "partial-needs-verify",
+    });
     serde_json::json!({
         "name": check.name,
         "description": check.desc,
         "binary": if check.uses_binary() { check.bin_name } else { "(built-in)" },
+        "install_key": check.install_key(),
+        "status": status,
+        "declared_version": declared_version,
         "patterns": patterns,
         "fix": check.has_fix(),
+        "fix_behavior": fix_behavior,
         "run_policy": run_policy_label(check),
         "slow": check.category == registry::Category::Slow,
+        "category": category_label(check.category),
         "scope": scope,
         "config_file": config_file,
+        "config_doc_url": check.config_doc_url,
+        "project_url": check.project_url,
+        "formatter": check.is_formatter,
+        "defers_to_formatters": check.defers_to_formatters,
+        "baseline_config": baseline_config,
+        "baseline_triggers": baseline_triggers,
+        "fix_after": check.fix_after,
     })
+}
+
+fn category_label(category: registry::Category) -> &'static str {
+    match category {
+        registry::Category::Lang => "lang",
+        registry::Category::Style => "style",
+        registry::Category::Default => "default",
+        registry::Category::Slow => "slow",
+    }
+}
+
+fn config_file_location(config: &registry::ConfigFile) -> String {
+    match config.base {
+        registry::ConfigBase::ProjectRoot => config.path.to_string(),
+        registry::ConfigBase::ConfigDir => format!("FLINT_CONFIG_DIR/{}", config.path),
+    }
 }
 
 fn canonical_config_path(config: &LinterConfig) -> String {
@@ -1180,7 +1252,10 @@ where
         } else {
             "no binary"
         }
-    } else if mise_tools.contains_key(check.bin_name) {
+    } else if check
+        .install_key()
+        .is_some_and(|key| mise_tools.contains_key(key))
+    {
         "wrong version"
     } else {
         "missing"
@@ -1299,6 +1374,24 @@ renovate-deps         renovate            active         adaptive  yes  Verify R
 license-header        (built-in)          not configured  fast      no   Check source files have the required license header
 "#
         );
+    }
+
+    #[test]
+    fn linter_json_exposes_registry_metadata() {
+        let check = registry::builtin()
+            .into_iter()
+            .find(|check| check.name == "rumdl")
+            .expect("rumdl check");
+
+        let json = super::linter_json(&check, "active", Some("0.2.31"));
+
+        assert_eq!(json["status"], "active");
+        assert_eq!(json["declared_version"], "0.2.31");
+        assert_eq!(json["install_key"], "rumdl");
+        assert_eq!(json["scope"], "files");
+        assert_eq!(json["formatter"], true);
+        assert!(json["project_url"].as_str().is_some());
+        assert!(json["baseline_config"].as_str().is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1025,16 +1025,23 @@ fn print_linters_json(
 ) {
     let entries: Vec<serde_json::Value> = registry
         .iter()
-        .map(|check| {
-            let status = linter_status(check, mise_tools, cfg, registry::binary_on_path);
-            let declared_version = check
-                .install_key()
-                .and_then(|key| mise_tools.get(key))
-                .map(String::as_str);
-            linter_json(check, status, declared_version)
-        })
+        .map(|check| linter_json_for(check, mise_tools, cfg, registry::binary_on_path))
         .collect();
     println!("{}", serde_json::to_string_pretty(&entries).unwrap());
+}
+
+fn linter_json_for<F>(
+    check: &registry::Check,
+    mise_tools: &HashMap<String, String>,
+    cfg: &config::Config,
+    binary_on_path: F,
+) -> serde_json::Value
+where
+    F: Fn(&str) -> bool,
+{
+    let status = linter_status(check, mise_tools, cfg, binary_on_path);
+    let declared_version = registry::declared_tool_version(check, mise_tools);
+    linter_json(check, status, declared_version)
 }
 
 pub fn linter_json(
@@ -1252,10 +1259,7 @@ where
         } else {
             "no binary"
         }
-    } else if check
-        .install_key()
-        .is_some_and(|key| mise_tools.contains_key(key))
-    {
+    } else if registry::declared_tool_version(check, mise_tools).is_some() {
         "wrong version"
     } else {
         "missing"
@@ -1392,6 +1396,25 @@ license-header        (built-in)          not configured  fast      no   Check s
         assert_eq!(json["formatter"], true);
         assert!(json["project_url"].as_str().is_some());
         assert!(json["baseline_config"].as_str().is_some());
+    }
+
+    #[test]
+    fn linter_json_and_status_use_bare_tool_alias_fallback() {
+        let check = registry::Check::files("ryl", "ryl {FILES}", &["*.yml"])
+            .mise_tool("aqua:owenlamont/ryl")
+            .version_req(">=1.0.0");
+        let cfg = config::Config::default();
+
+        let active_tools = mise_tools_from("[tools]\nryl = \"1.2.3\"\n");
+        let json = super::linter_json_for(&check, &active_tools, &cfg, |_| true);
+        assert_eq!(json["status"], "active");
+        assert_eq!(json["declared_version"], "1.2.3");
+
+        let wrong_version_tools = mise_tools_from("[tools]\nryl = \"0.6.0\"\n");
+        assert_eq!(
+            linter_status(&check, &wrong_version_tools, &cfg, |_| true),
+            "wrong version"
+        );
     }
 
     #[test]

--- a/src/registry/mise.rs
+++ b/src/registry/mise.rs
@@ -188,7 +188,7 @@ fn is_github_owner_and_flint_repo_or_git(path: &str) -> bool {
     matches!(path.split_once('/'), Some((owner, "flint" | "flint.git")) if !owner.is_empty())
 }
 
-fn declared_tool_version<'a>(
+pub(crate) fn declared_tool_version<'a>(
     check: &Check,
     mise_tools: &'a HashMap<String, String>,
 ) -> Option<&'a str> {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -5,6 +5,7 @@ mod resolve;
 mod types;
 
 pub use checks::builtin;
+pub(crate) use mise::declared_tool_version;
 pub use mise::{
     check_active, flint_version_changed, full_baseline_runtime_changed, read_mise_tools,
     read_mise_tools_at_ref, runtime_version_changed, tool_version_changed,


### PR DESCRIPTION
## Summary

- add focused `flint init --only` setup
- improve setup detection, migrations, and comment preservation
- expose richer linter metadata through `flint linters --json`
- document the focused init behavior

## Validation

- `mise run lint:fix`
- `cargo test` (287 unit tests and 10 integration tests passed; 1 network-dependent test ignored)
