### PR TITLE
ci: validate curated mise registry backends

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -83,6 +83,11 @@
         "mise"
       ]
     },
+    ".github/workflows/mise-registry.yml": {
+      "regex": [
+        "mise"
+      ]
+    },
     ".github/workflows/release-plz.yml": {
       "regex": [
         "mise"

--- a/.github/workflows/mise-registry.yml
+++ b/.github/workflows/mise-registry.yml
@@ -1,0 +1,27 @@
+name: Mise registry compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Setup mise
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: v2026.7.7
+          sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+      - name: Validate curated tool backends
+        run: mise run validate-mise-registry

--- a/.github/workflows/mise-registry.yml
+++ b/.github/workflows/mise-registry.yml
@@ -10,6 +10,8 @@ permissions: {}
 jobs:
   validate:
     runs-on: ubuntu-24.04
+    env:
+      MISE_ENABLE_TOOLS: rust
     permissions:
       contents: read
     steps:
@@ -23,5 +25,8 @@ jobs:
         with:
           version: v2026.7.7
           sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+          cache_key: "{{default}}-{{env.MISE_ENABLE_TOOLS}}"
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Validate curated tool backends
         run: mise run validate-mise-registry

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,6 +16,8 @@ jobs:
     name: Create Release
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'grafana/flint' }}
+    env:
+      MISE_ENABLE_TOOLS: release-plz
     permissions:
       actions: write
       contents: write
@@ -29,6 +31,7 @@ jobs:
         with:
           version: v2026.7.7
           sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+          cache_key: "{{default}}-{{env.MISE_ENABLE_TOOLS}}"
       - name: Create release metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,6 +46,8 @@ jobs:
     needs: [release]
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'grafana/flint' }}
+    env:
+      MISE_ENABLE_TOOLS: release-plz
     permissions:
       contents: write
       pull-requests: write
@@ -59,6 +64,7 @@ jobs:
         with:
           version: v2026.7.7
           sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+          cache_key: "{{default}}-{{env.MISE_ENABLE_TOOLS}}"
       - name: Update release PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mise/tasks/validate-mise-registry
+++ b/.mise/tasks/validate-mise-registry
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#MISE description="Validate curated mise registry backends"
+set -euo pipefail
+
+# This is intentionally a networked compatibility check. The normal Rust
+# registry tests stay offline and validate only Flint's metadata contract.
+command -v jq >/dev/null || {
+	echo "validate-mise-registry: jq is required" >&2
+	exit 1
+}
+command -v mise >/dev/null || {
+	echo "validate-mise-registry: mise is required" >&2
+	exit 1
+}
+
+failures=0
+
+# Keep the registry query separate from the validation loop so it is clear
+# which checks are being validated.
+external_linter_backends="$(
+    cargo run -q --bin flint -- linters --json |
+        jq -r '.[] | select(.install_key != null and .binary != "(built-in)") |
+      [.name, .install_key] | @tsv'
+)"
+
+while IFS=$'\t' read -r name install_key; do
+	case "$install_key" in
+	cargo:* | npm:* | pipx:* | rust | go | dotnet)
+		# These are intentionally non-Aqua backends and are covered by their
+		# package-manager/toolchain ecosystems rather than the Aqua registry.
+		printf 'skipping non-Aqua backend: %s (%s)\n' "$name" "$install_key"
+		;;
+	*)
+		if ! mise ls-remote "$install_key" >/dev/null 2>&1; then
+			printf 'mise registry lookup failed: %s (%s)\n' "$name" "$install_key" >&2
+			failures=$((failures + 1))
+		fi
+		;;
+	esac
+done <<< "$external_linter_backends"
+
+if ((failures > 0)); then
+	printf 'validate-mise-registry: %d backend lookup(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+echo "validate-mise-registry: all curated external backends resolved"


### PR DESCRIPTION
## Summary

- add the executable `.mise/tasks/validate-mise-registry` file task
- validate curated external backends through `mise run validate-mise-registry`
- add the scheduled GitHub Actions compatibility workflow and Renovate tracking

Stacked on the init/setup PR.

## Validation

- `mise run validate-mise-registry`
- `mise run lint:fix`
