### PR TITLE
feat: add standalone Checkstyle, dotenv, and kube linting

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -4,12 +4,20 @@
       "packageName": "rhysd/actionlint",
       "datasource": "github-releases"
     },
+    "aqua:dotenv-linter/dotenv-linter": {
+      "packageName": "dotenv-linter/dotenv-linter",
+      "datasource": "github-tags"
+    },
     "aqua:jonwiggins/xmloxide": {
       "packageName": "jonwiggins/xmloxide",
       "datasource": "github-tags"
     },
     "aqua:owenlamont/ryl": {
       "packageName": "owenlamont/ryl",
+      "datasource": "github-tags"
+    },
+    "aqua:stackrox/kube-linter": {
+      "packageName": "stackrox/kube-linter",
       "datasource": "github-tags"
     },
     "biome": {
@@ -106,11 +114,14 @@
     "mise.toml": {
       "mise": [
         "actionlint",
+        "aqua:dotenv-linter/dotenv-linter",
         "aqua:jonwiggins/xmloxide",
         "aqua:owenlamont/ryl",
+        "aqua:stackrox/kube-linter",
         "biome",
         "dotnet",
         "editorconfig-checker",
+        "github:checkstyle/checkstyle",
         "go",
         "golangci-lint",
         "google-java-format",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,10 +57,13 @@
     {
       matchDepNames: [
         "actionlint",
+        "aqua:dotenv-linter/dotenv-linter",
         "aqua:jonwiggins/xmloxide",
         "aqua:owenlamont/ryl",
+        "aqua:stackrox/kube-linter",
         "biome",
         "editorconfig-checker",
+        "github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]",
         "golangci-lint",
         "google-java-format",
         "hadolint",

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For Flint contributor workflow and local testing tips, see
 | ----------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
 | C#                      | —                                                | [`dotnet-format`](docs/linters.md#dotnet-format)           |
 | Go                      | [`golangci-lint`](docs/linters.md#golangci-lint) | [`gofmt`](docs/linters.md#gofmt)                           |
-| Java                    | —                                                | [`google-java-format`](docs/linters.md#google-java-format) |
+| Java                    | [`checkstyle`](docs/linters.md#checkstyle)       | [`google-java-format`](docs/linters.md#google-java-format) |
 | JavaScript / TypeScript | [`biome`](docs/linters.md#biome)                 | [`biome-format`](docs/linters.md#biome-format)             |
 | Kotlin                  | [`ktlint`](docs/linters.md#ktlint)               | [`ktlint`](docs/linters.md#ktlint)                         |
 | Python                  | [`ruff`](docs/linters.md#ruff)                   | [`ruff-format`](docs/linters.md#ruff-format)               |
@@ -158,21 +158,23 @@ For Flint contributor workflow and local testing tips, see
 
 ### Files / Formats
 
-| Name     | Linter                                     | Formatter                                      |
-| -------- | ------------------------------------------ | ---------------------------------------------- |
-| JSON     | [`biome`](docs/linters.md#biome)           | [`biome-format`](docs/linters.md#biome-format) |
-| Markdown | [`rumdl`](docs/linters.md#rumdl)           | [`rumdl`](docs/linters.md#rumdl)               |
-| Shell    | [`shellcheck`](docs/linters.md#shellcheck) | [`shfmt`](docs/linters.md#shfmt)               |
-| TOML     | —                                          | [`taplo`](docs/linters.md#taplo)               |
-| XML      | [`xmllint`](docs/linters.md#xmllint)       | —                                              |
-| YAML     | [`ryl`](docs/linters.md#ryl)               | [`ryl`](docs/linters.md#ryl)                   |
+| Name     | Linter                                           | Formatter                                        |
+| -------- | ------------------------------------------------ | ------------------------------------------------ |
+| Dotenv   | [`dotenv-linter`](docs/linters.md#dotenv-linter) | [`dotenv-linter`](docs/linters.md#dotenv-linter) |
+| JSON     | [`biome`](docs/linters.md#biome)                 | [`biome-format`](docs/linters.md#biome-format)   |
+| Markdown | [`rumdl`](docs/linters.md#rumdl)                 | [`rumdl`](docs/linters.md#rumdl)                 |
+| Shell    | [`shellcheck`](docs/linters.md#shellcheck)       | [`shfmt`](docs/linters.md#shfmt)                 |
+| TOML     | —                                                | [`taplo`](docs/linters.md#taplo)                 |
+| XML      | [`xmllint`](docs/linters.md#xmllint)             | —                                                |
+| YAML     | [`ryl`](docs/linters.md#ryl)                     | [`ryl`](docs/linters.md#ryl)                     |
 
 ### Tooling / CI
 
-| Name           | Check                                                                           |
-| -------------- | ------------------------------------------------------------------------------- |
-| Dockerfile     | [`hadolint`](docs/linters.md#hadolint)                                          |
-| GitHub Actions | [`actionlint`](docs/linters.md#actionlint) / [`zizmor`](docs/linters.md#zizmor) |
+| Name                 | Check                                                                           |
+| -------------------- | ------------------------------------------------------------------------------- |
+| Dockerfile           | [`hadolint`](docs/linters.md#hadolint)                                          |
+| GitHub Actions       | [`actionlint`](docs/linters.md#actionlint) / [`zizmor`](docs/linters.md#zizmor) |
+| Kubernetes manifests | [`kube-linter`](docs/linters.md#kube-linter)                                    |
 
 ### General
 

--- a/default.json
+++ b/default.json
@@ -21,10 +21,13 @@
     {
       "matchDepNames": [
         "actionlint",
+        "aqua:dotenv-linter/dotenv-linter",
         "aqua:jonwiggins/xmloxide",
         "aqua:owenlamont/ryl",
+        "aqua:stackrox/kube-linter",
         "biome",
         "editorconfig-checker",
+        "github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]",
         "golangci-lint",
         "google-java-format",
         "hadolint",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,6 +186,7 @@ use `--only`:
 
 ```bash
 flint init --only rumdl
+flint init --only checkstyle dotenv
 ```
 
 Focused init preserves unrelated tools and configuration, rejects unknown

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -15,7 +15,7 @@ links to the relevant upstream configuration docs.
 | ----------------------- | --------------------------------- | ------------------------------------------- |
 | C#                      | —                                 | [`dotnet-format`](#dotnet-format)           |
 | Go                      | [`golangci-lint`](#golangci-lint) | [`gofmt`](#gofmt)                           |
-| Java                    | —                                 | [`google-java-format`](#google-java-format) |
+| Java                    | [`checkstyle`](#checkstyle)       | [`google-java-format`](#google-java-format) |
 | JavaScript / TypeScript | [`biome`](#biome)                 | [`biome-format`](#biome-format)             |
 | Kotlin                  | [`ktlint`](#ktlint)               | [`ktlint`](#ktlint)                         |
 | Python                  | [`ruff`](#ruff)                   | [`ruff-format`](#ruff-format)               |
@@ -23,21 +23,23 @@ links to the relevant upstream configuration docs.
 
 ### Files / Formats
 
-| Name     | Linter                      | Formatter                       |
-| -------- | --------------------------- | ------------------------------- |
-| JSON     | [`biome`](#biome)           | [`biome-format`](#biome-format) |
-| Markdown | [`rumdl`](#rumdl)           | [`rumdl`](#rumdl)               |
-| Shell    | [`shellcheck`](#shellcheck) | [`shfmt`](#shfmt)               |
-| TOML     | —                           | [`taplo`](#taplo)               |
-| XML      | [`xmllint`](#xmllint)       | —                               |
-| YAML     | [`ryl`](#ryl)               | [`ryl`](#ryl)                   |
+| Name     | Linter                            | Formatter                         |
+| -------- | --------------------------------- | --------------------------------- |
+| Dotenv   | [`dotenv-linter`](#dotenv-linter) | [`dotenv-linter`](#dotenv-linter) |
+| JSON     | [`biome`](#biome)                 | [`biome-format`](#biome-format)   |
+| Markdown | [`rumdl`](#rumdl)                 | [`rumdl`](#rumdl)                 |
+| Shell    | [`shellcheck`](#shellcheck)       | [`shfmt`](#shfmt)                 |
+| TOML     | —                                 | [`taplo`](#taplo)                 |
+| XML      | [`xmllint`](#xmllint)             | —                                 |
+| YAML     | [`ryl`](#ryl)                     | [`ryl`](#ryl)                     |
 
 ### Tooling / CI
 
-| Name           | Check                                             |
-| -------------- | ------------------------------------------------- |
-| Dockerfile     | [`hadolint`](#hadolint)                           |
-| GitHub Actions | [`actionlint`](#actionlint) / [`zizmor`](#zizmor) |
+| Name                 | Check                                             |
+| -------------------- | ------------------------------------------------- |
+| Dockerfile           | [`hadolint`](#hadolint)                           |
+| GitHub Actions       | [`actionlint`](#actionlint) / [`zizmor`](#zizmor) |
+| Kubernetes manifests | [`kube-linter`](#kube-linter)                     |
 
 ### General
 
@@ -114,6 +116,44 @@ Lint Rust code; runs on all .rs files, not just changed
 | Config   | [`rustfmt.toml`](https://github.com/rust-lang/rustfmt?tab=readme-ov-file#configuring-rustfmt) |
 
 Format Rust code; runs on all .rs files, not just changed
+
+### [`checkstyle`](https://github.com/checkstyle/checkstyle)
+
+|          |                                                        |
+| -------- | ------------------------------------------------------ |
+| Fix      | no                                                     |
+| Binary   | `checkstyle`                                           |
+| Scope    | [files](#scope-files)                                  |
+| Patterns | `*.java`                                               |
+| Config   | [`checkstyle.xml`](https://checkstyle.org/config.html) |
+
+Check Java source against a repository-owned Checkstyle configuration
+
+Runs the standalone Checkstyle CLI against selected Java files.
+A Java runtime must be available on PATH because the curated
+Checkstyle distribution is a JAR.
+The repository must provide checkstyle.xml at its root; a root-level
+checkstyle-suppressions.xml is also supported by Checkstyle's normal
+property default. Flint does not infer Maven or Gradle source roots,
+and Checkstyle is report-only: use a formatter such as
+google-java-format for safe formatting fixes.
+
+### [`dotenv-linter`](https://github.com/dotenv-linter/dotenv-linter)
+
+|          |                       |
+| -------- | --------------------- |
+| Fix      | yes                   |
+| Binary   | `dotenv-linter`       |
+| Scope    | [files](#scope-files) |
+| Patterns | `.env .env.* *.env`   |
+
+Lint dotenv environment files without printing their values
+
+Checks only explicit .env-style files: .env, .env.* and files ending in .env.
+Flint passes file paths rather than a directory, so an unrelated YAML, Compose,
+or application config file is never scanned. Check mode is read-only; fix mode
+uses dotenv-linter's no-backup option and remains serialized with other Flint
+fixers. Do not commit secret-bearing .env files.
 
 ### [`dotnet-format`](https://learn.microsoft.com/dotnet/core/tools/dotnet-format)
 
@@ -233,6 +273,25 @@ Lint Dockerfiles
 | Patterns | `*.kt *.kts`          |
 
 Lint and format Kotlin code
+
+### [`kube-linter`](https://github.com/stackrox/kube-linter)
+
+|          |                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------ |
+| Fix      | no                                                                                         |
+| Binary   | `kube-linter`                                                                              |
+| Scope    | [native](#scope-native)                                                                    |
+| Patterns | `k8s/*.yml k8s/*.yaml kubernetes/*.yml kubernetes/*.yaml manifests/*.yml manifests/*.yaml` |
+| Config   | [`kube-linter.yaml`](https://docs.kubelinter.io/)                                          |
+
+Lint explicitly selected Kubernetes resources
+
+KubeLinter is report-only and only runs on files selected by
+[checks.kube-linter].paths (or existing conventional k8s/,
+kubernetes/, or manifests/ directories). Flint parses YAML documents
+and passes only documents containing apiVersion and kind, so ordinary
+YAML and Docker Compose files are not treated as Kubernetes resources.
+Helm/Kustomize rendering remains an explicit separate workflow.
 
 ### `license-header`
 

--- a/mise.toml
+++ b/mise.toml
@@ -10,10 +10,13 @@ rust = { version = "1.97.1", components = "clippy,rustfmt" }
 
 # Linters
 actionlint = "1.7.12"
+"aqua:dotenv-linter/dotenv-linter" = "4.0.0"
 "aqua:jonwiggins/xmloxide" = "0.4.3"
 "aqua:owenlamont/ryl" = "0.21.0"
+"aqua:stackrox/kube-linter" = "0.8.3"
 biome = "2.5.4"
 editorconfig-checker = "3.8.0"
+"github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]" = "checkstyle-13.8.0"
 golangci-lint = "2.12.2"
 google-java-format = "1.35.0"
 hadolint = "2.14.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,12 +36,29 @@ impl Default for Settings {
 #[serde(default)]
 pub struct ChecksConfig {
     pub lychee: LycheeConfig,
+    #[serde(rename = "kube-linter", alias = "kube_linter")]
+    pub kube_linter: KubeLinterConfig,
     // The alias allows the underscore form used in env var keys alongside the
     // hyphenated form used in flint.toml.
     #[serde(rename = "renovate-deps", alias = "renovate_deps")]
     pub renovate_deps: RenovateDepsConfig,
     #[serde(rename = "license-header", alias = "license_header")]
     pub license_header: LicenseHeaderConfig,
+}
+
+/// Configuration for the report-only Kubernetes manifest check.
+///
+/// When `paths` is empty, Flint considers only conventional Kubernetes
+/// directories that exist in the project. It deliberately does not discover
+/// YAML files from the repository at large, which keeps Compose and unrelated
+/// YAML out of kube-linter's input set.
+#[derive(Debug, Default, Deserialize, Clone)]
+#[serde(default)]
+pub struct KubeLinterConfig {
+    /// Files or directories to inspect, relative to the project root.
+    pub paths: Vec<String>,
+    /// Optional kube-linter config filename, relative to `FLINT_CONFIG_DIR`.
+    pub config: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, Clone)]

--- a/src/linters/kube_linter.rs
+++ b/src/linters/kube_linter.rs
@@ -1,0 +1,352 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use crate::config::KubeLinterConfig;
+use crate::linters::LinterOutput;
+use crate::registry::{
+    CheckTypeDef, NativeCheckDef, NativePrepareContext, NativeRunContext, NativeRunFuture,
+    PreparedNativeCheck,
+};
+use serde::Deserialize;
+
+/// Conventional directories are intentionally narrow. In particular, this
+/// must not become a repository-wide `*.yaml` scan because Compose and other
+/// application YAML files are not Kubernetes manifests.
+const DEFAULT_MANIFEST_DIRECTORIES: &[&str] = &["k8s", "kubernetes", "manifests"];
+const CONFIG_FILE_NAMES: &[&str] = &["kube-linter.yaml"];
+
+pub(crate) static CHECK_TYPE: CheckTypeDef = CheckTypeDef::native(
+    "kube-linter",
+    NativeCheckDef::with_bin("kube-linter", prepare)
+        .with_config_display("via `[checks.kube-linter]` in flint.toml"),
+);
+
+#[derive(Debug)]
+struct PreparedKubeLinter {
+    name: String,
+    files: Vec<PathBuf>,
+    config: Option<PathBuf>,
+}
+
+fn prepare(ctx: NativePrepareContext<'_>) -> Option<Box<dyn PreparedNativeCheck>> {
+    let cfg = &ctx.cfg.checks.kube_linter;
+    let files = select_manifest_files(ctx.project_root, cfg);
+    let config = find_config_file(ctx.config_dir, cfg);
+
+    // Keep an empty prepared check so run() can report a successful no-op
+    // instead of making an empty manifest set look like a missing check.
+    Some(Box::new(PreparedKubeLinter {
+        name: ctx.name.to_string(),
+        files,
+        config,
+    }))
+}
+
+impl PreparedNativeCheck for PreparedKubeLinter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn run(self: Box<Self>, ctx: NativeRunContext) -> NativeRunFuture {
+        Box::pin(async move { run(&ctx.project_root, &self.files, self.config.as_deref()).await })
+    }
+}
+
+/// Select existing YAML files containing at least one Kubernetes-shaped YAML
+/// document. Explicit paths take precedence over defaults; a directory is
+/// traversed recursively, but only `.yaml`/`.yml` files are considered.
+fn select_manifest_files(project_root: &Path, cfg: &KubeLinterConfig) -> Vec<PathBuf> {
+    let roots: Vec<PathBuf> = if cfg.paths.is_empty() {
+        DEFAULT_MANIFEST_DIRECTORIES
+            .iter()
+            .map(|path| project_root.join(path))
+            .filter(|path| path.is_dir())
+            .collect()
+    } else {
+        cfg.paths
+            .iter()
+            .map(|path| resolve_project_path(project_root, path))
+            .collect()
+    };
+
+    let mut yaml_files = BTreeSet::new();
+    for root in roots {
+        collect_yaml_files(&root, &mut yaml_files);
+    }
+
+    yaml_files
+        .into_iter()
+        .filter(|path| path.is_file())
+        .filter(|path| is_kubernetes_manifest(path))
+        .collect()
+}
+
+fn resolve_project_path(project_root: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    }
+}
+
+fn collect_yaml_files(path: &Path, files: &mut BTreeSet<PathBuf>) {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        if metadata.is_file() && is_yaml_path(path) {
+            files.insert(path.to_path_buf());
+        }
+        return;
+    }
+
+    if !metadata.is_dir() {
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        collect_yaml_files(&entry.path(), files);
+    }
+}
+
+fn is_yaml_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "yaml" | "yml"))
+}
+
+fn is_kubernetes_manifest(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+
+    serde_yaml_bw::Deserializer::from_str(&content).any(|document| {
+        let Ok(value) = serde_yaml_bw::Value::deserialize(document) else {
+            return false;
+        };
+        let serde_yaml_bw::Value::Mapping(mapping) = value else {
+            return false;
+        };
+        has_mapping_key(&mapping, "apiVersion") && has_mapping_key(&mapping, "kind")
+    })
+}
+
+fn has_mapping_key(mapping: &serde_yaml_bw::Mapping, expected: &str) -> bool {
+    mapping.keys().any(|key| key.as_str() == Some(expected))
+}
+
+fn find_config_file(config_dir: &Path, cfg: &KubeLinterConfig) -> Option<PathBuf> {
+    if let Some(config) = cfg.config.as_deref() {
+        let configured = resolve_config_path(config_dir, config);
+        if configured.is_file() {
+            return Some(configured);
+        }
+    }
+
+    CONFIG_FILE_NAMES
+        .iter()
+        .map(|name| config_dir.join(name))
+        .find(|path| path.is_file())
+}
+
+fn resolve_config_path(config_dir: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+async fn run(project_root: &Path, files: &[PathBuf], config: Option<&Path>) -> LinterOutput {
+    if files.is_empty() {
+        return LinterOutput {
+            ok: true,
+            stdout: b"No Kubernetes manifests found; skipping kube-linter.\n".to_vec(),
+            stderr: Vec::new(),
+            setup_outcome: None,
+        };
+    }
+
+    let mut argv = vec!["kube-linter".to_string(), "lint".to_string()];
+    if let Some(config) = config {
+        argv.push("--config".to_string());
+        argv.push(path_for_command(project_root, config));
+    }
+    argv.extend(
+        files
+            .iter()
+            .map(|path| path_for_command(project_root, path)),
+    );
+
+    let mut command = crate::linters::spawn_command(&argv, false);
+    command
+        .current_dir(project_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match command.output().await {
+        Ok(output) => LinterOutput {
+            ok: output.status.success(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+            setup_outcome: None,
+        },
+        Err(error) => LinterOutput {
+            ok: false,
+            stdout: Vec::new(),
+            stderr: format!("flint: kube-linter: failed to spawn kube-linter: {error}\n")
+                .into_bytes(),
+            setup_outcome: None,
+        },
+    }
+}
+
+fn path_for_command(project_root: &Path, path: &Path) -> String {
+    path.strip_prefix(project_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn explicit_directories_select_kubernetes_documents_but_not_compose() {
+        let project = tempfile::tempdir().unwrap();
+        write(
+            &project.path().join("manifests/deployment.yaml"),
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n",
+        );
+        write(
+            &project.path().join("manifests/compose.yml"),
+            "services:\n  app:\n    image: example/app\n",
+        );
+        write(
+            &project.path().join("manifests/values.yaml"),
+            "replicaCount: 2\n",
+        );
+
+        let files = select_manifest_files(
+            project.path(),
+            &KubeLinterConfig {
+                paths: vec!["manifests".into()],
+                config: None,
+            },
+        );
+
+        assert_eq!(
+            files,
+            vec![project.path().join("manifests/deployment.yaml")]
+        );
+    }
+
+    #[test]
+    fn multi_document_yaml_is_selected_when_any_document_is_kubernetes() {
+        let project = tempfile::tempdir().unwrap();
+        let path = project.path().join("k8s/resources.yaml");
+        write(
+            &path,
+            "---\nservices:\n  app:\n    image: example/app\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: app\n",
+        );
+
+        let files = select_manifest_files(
+            project.path(),
+            &KubeLinterConfig {
+                paths: vec!["k8s/resources.yaml".into()],
+                config: None,
+            },
+        );
+
+        assert_eq!(files, vec![path]);
+    }
+
+    #[test]
+    fn defaults_use_only_existing_conventional_directories() {
+        let project = tempfile::tempdir().unwrap();
+        write(
+            &project.path().join("kubernetes/service.yml"),
+            "apiVersion: v1\nkind: Service\nmetadata:\n  name: app\n",
+        );
+        write(
+            &project.path().join("unrelated/secret.yaml"),
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: secret\n",
+        );
+
+        let files = select_manifest_files(project.path(), &KubeLinterConfig::default());
+
+        assert_eq!(files, vec![project.path().join("kubernetes/service.yml")]);
+    }
+
+    #[test]
+    fn config_prefers_explicit_config_then_canonical_config_name() {
+        let project = tempfile::tempdir().unwrap();
+        let config_dir = project.path().join("config");
+        write(&config_dir.join("custom.yaml"), "checks: {}\n");
+        write(&config_dir.join("kube-linter.yaml"), "checks: {}\n");
+
+        let explicit = find_config_file(
+            &config_dir,
+            &KubeLinterConfig {
+                paths: Vec::new(),
+                config: Some("custom.yaml".into()),
+            },
+        );
+        assert_eq!(explicit, Some(config_dir.join("custom.yaml")));
+
+        let conventional = find_config_file(&config_dir, &KubeLinterConfig::default());
+        assert_eq!(conventional, Some(config_dir.join("kube-linter.yaml")));
+    }
+
+    #[test]
+    fn missing_paths_and_config_are_a_noop() {
+        let project = tempfile::tempdir().unwrap();
+        let cfg = KubeLinterConfig {
+            paths: vec!["does-not-exist".into()],
+            config: Some("missing.yaml".into()),
+        };
+
+        assert!(select_manifest_files(project.path(), &cfg).is_empty());
+        assert!(find_config_file(&project.path().join("config"), &cfg).is_none());
+    }
+
+    #[test]
+    fn config_accepts_the_hyphenated_check_name_and_explicit_paths() {
+        let config: crate::config::Config = toml::from_str(
+            r#"
+                [checks.kube-linter]
+                paths = ["k8s", "manifests"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.checks.kube_linter.paths,
+            vec!["k8s".to_string(), "manifests".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn no_selected_files_is_a_clean_noop() {
+        let project = tempfile::tempdir().unwrap();
+        let output = run(project.path(), &[], None).await;
+
+        assert!(output.ok);
+        assert!(output.stderr.is_empty());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("skipping kube-linter"));
+    }
+}

--- a/src/linters/mod.rs
+++ b/src/linters/mod.rs
@@ -1,6 +1,7 @@
 pub mod biome;
 pub mod env;
 pub mod flint_setup;
+pub mod kube_linter;
 pub mod license_header;
 pub mod lychee;
 pub mod renovate_deps;
@@ -21,13 +22,13 @@ pub use crate::registry::LinterOutput;
 /// - PE binary without extension → execute directly by full path
 /// - Everything else → route through `cmd.exe /C` to handle `.cmd` shims
 ///
-/// Self-executing JARs (e.g. ktlint) cannot run via cmd.exe at all.
-/// When `windows_java_jar` is true the binary is resolved to its full path
-/// and invoked as `java -jar <path>`.
-pub fn spawn_command(argv: &[String], windows_java_jar: bool) -> tokio::process::Command {
+/// Self-executing JARs (e.g. ktlint and Checkstyle) need to be invoked through
+/// the JVM. When `java_jar` is true the resolved tool path is invoked as
+/// `java -jar <path>` on every platform.
+pub fn spawn_command(argv: &[String], java_jar: bool) -> tokio::process::Command {
     #[cfg(windows)]
     {
-        if windows_java_jar {
+        if java_jar {
             if let Some(path) = find_file_in_path(&argv[0]) {
                 let mut cmd = tokio::process::Command::new("java");
                 cmd.arg("-jar").arg(path).args(&argv[1..]);
@@ -44,7 +45,12 @@ pub fn spawn_command(argv: &[String], windows_java_jar: bool) -> tokio::process:
     }
     #[cfg(not(windows))]
     {
-        let _ = windows_java_jar;
+        if java_jar {
+            let jar = find_file_in_path(&argv[0]).unwrap_or_else(|| argv[0].clone().into());
+            let mut cmd = tokio::process::Command::new("java");
+            cmd.arg("-jar").arg(jar).args(&argv[1..]);
+            return cmd;
+        }
         let mut cmd = tokio::process::Command::new(&argv[0]);
         cmd.args(&argv[1..]);
         cmd
@@ -79,8 +85,17 @@ fn find_pe_binary(binary: &str) -> Option<std::path::PathBuf> {
 
 /// On Windows, return the full path of `binary` from PATH without inspecting
 /// its contents. Used for self-executing JARs where the caller already knows
-/// the invocation style (i.e. `windows_java_jar` is set in the registry).
+/// the invocation style (i.e. `java_jar` is set in the registry).
 #[cfg(windows)]
+fn find_file_in_path(binary: &str) -> Option<std::path::PathBuf> {
+    let path_var = std::env::var("PATH").ok()?;
+    std::env::split_paths(&path_var).find_map(|dir| {
+        let candidate = dir.join(binary);
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+#[cfg(not(windows))]
 fn find_file_in_path(binary: &str) -> Option<std::path::PathBuf> {
     let path_var = std::env::var("PATH").ok()?;
     std::env::split_paths(&path_var).find_map(|dir| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1348,33 +1348,36 @@ rust = { version = "1.94.1", components = "clippy,rustfmt" }
 
         assert_eq!(
             table,
-            r#"NAME                  BINARY              STATUS         SPEED     FIX  DESCRIPTION                                                          PATTERNS
--------------------------------------------------------------------------------------------------------------------------------------------------------
-flint-setup           (built-in)          active         fast      yes  Keep Flint setup current and mise.toml lint tooling canonical        mise.toml
-shellcheck            shellcheck          active         fast      no   Lint shell scripts for common mistakes                               *.sh *.bash *.bats
-shfmt                 shfmt               active         fast      yes  Format shell scripts                                                 *.sh *.bash
-rumdl                 rumdl               active         fast      yes  Lint Markdown files for style and consistency                        *.md
-ryl                   ryl                 active         fast      yes  Lint YAML files for style and consistency                            *.yml *.yaml
-taplo                 taplo               active         fast      yes  Format TOML files                                                    *.toml
-actionlint            actionlint          active         fast      no   Lint GitHub Actions workflow files                                   .github/workflows/*.yml .github/workflows/*.yaml
-zizmor                zizmor              active         fast      yes  Audit GitHub Actions workflows for security issues                   .github/workflows/*.yml .github/workflows/*.yaml
-hadolint              hadolint            missing        fast      no   Lint Dockerfiles                                                     Dockerfile Dockerfile.* *.dockerfile
-xmllint               xmllint             missing        fast      no   Validate XML files are well-formed                                   *.xml
-typos                 typos               active         fast      yes  Check for common spelling mistakes                                   *
-editorconfig-checker  ec                  active         fast      no   Check files comply with EditorConfig settings                        *
-golangci-lint         golangci-lint       missing        fast      no   Lint Go code; uses --new-from-rev to scope analysis to changed code  *.go
-ruff                  ruff                active         fast      yes  Lint Python code                                                     *.py
-ruff-format           ruff                active         fast      yes  Format Python code                                                   *.py
-biome                 biome               active         fast      yes  Lint JS/TS/JSON files                                                *.json *.jsonc *.js *.ts *.jsx *.tsx
-biome-format          biome               active         fast      yes  Format JS/TS/JSON files                                              *.json *.jsonc *.js *.ts *.jsx *.tsx
-cargo-clippy          cargo-clippy        active         fast      yes  Lint Rust code; runs on all .rs files, not just changed              *.rs
-cargo-fmt             rustfmt             active         fast      yes  Format Rust code; runs on all .rs files, not just changed            *.rs
-gofmt                 gofmt               missing        fast      yes  Format Go code                                                       *.go
-google-java-format    google-java-format  missing        fast      yes  Format Java code                                                     *.java
-ktlint                ktlint              missing        fast      yes  Lint and format Kotlin code                                          *.kt *.kts
-dotnet-format         dotnet              missing        fast      yes  Format C# code                                                       *.cs
+            r#"NAME                  BINARY              STATUS         SPEED     FIX  DESCRIPTION                                                            PATTERNS
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+flint-setup           (built-in)          active         fast      yes  Keep Flint setup current and mise.toml lint tooling canonical          mise.toml
+shellcheck            shellcheck          active         fast      no   Lint shell scripts for common mistakes                                 *.sh *.bash *.bats
+shfmt                 shfmt               active         fast      yes  Format shell scripts                                                   *.sh *.bash
+rumdl                 rumdl               active         fast      yes  Lint Markdown files for style and consistency                          *.md
+ryl                   ryl                 active         fast      yes  Lint YAML files for style and consistency                              *.yml *.yaml
+kube-linter           kube-linter         missing        fast      no   Lint explicitly selected Kubernetes resources                          k8s/*.yml k8s/*.yaml kubernetes/*.yml kubernetes/*.yaml manifests/*.yml manifests/*.yaml
+taplo                 taplo               active         fast      yes  Format TOML files                                                      *.toml
+actionlint            actionlint          active         fast      no   Lint GitHub Actions workflow files                                     .github/workflows/*.yml .github/workflows/*.yaml
+zizmor                zizmor              active         fast      yes  Audit GitHub Actions workflows for security issues                     .github/workflows/*.yml .github/workflows/*.yaml
+hadolint              hadolint            missing        fast      no   Lint Dockerfiles                                                       Dockerfile Dockerfile.* *.dockerfile
+xmllint               xmllint             missing        fast      no   Validate XML files are well-formed                                     *.xml
+typos                 typos               active         fast      yes  Check for common spelling mistakes                                     *
+dotenv-linter         dotenv-linter       missing        fast      yes  Lint dotenv environment files without printing their values            .env .env.* *.env
+editorconfig-checker  ec                  active         fast      no   Check files comply with EditorConfig settings                          *
+golangci-lint         golangci-lint       missing        fast      no   Lint Go code; uses --new-from-rev to scope analysis to changed code    *.go
+ruff                  ruff                active         fast      yes  Lint Python code                                                       *.py
+ruff-format           ruff                active         fast      yes  Format Python code                                                     *.py
+biome                 biome               active         fast      yes  Lint JS/TS/JSON files                                                  *.json *.jsonc *.js *.ts *.jsx *.tsx
+biome-format          biome               active         fast      yes  Format JS/TS/JSON files                                                *.json *.jsonc *.js *.ts *.jsx *.tsx
+cargo-clippy          cargo-clippy        active         fast      yes  Lint Rust code; runs on all .rs files, not just changed                *.rs
+cargo-fmt             rustfmt             active         fast      yes  Format Rust code; runs on all .rs files, not just changed              *.rs
+gofmt                 gofmt               missing        fast      yes  Format Go code                                                         *.go
+google-java-format    google-java-format  missing        fast      yes  Format Java code                                                       *.java
+checkstyle            checkstyle          missing        fast      no   Check Java source against a repository-owned Checkstyle configuration  *.java
+ktlint                ktlint              missing        fast      yes  Lint and format Kotlin code                                            *.kt *.kts
+dotnet-format         dotnet              missing        fast      yes  Format C# code                                                         *.cs
 lychee                lychee              active         fast      no   Check for broken links
-renovate-deps         renovate            active         adaptive  yes  Verify Renovate dependency snapshot is up to date                    renovate.json renovate.json5 .github/renovate.json .github/renovate.json5 .renovaterc .renovaterc.json .renovaterc.json5
+renovate-deps         renovate            active         adaptive  yes  Verify Renovate dependency snapshot is up to date                      renovate.json renovate.json5 .github/renovate.json .github/renovate.json5 .renovaterc .renovaterc.json .renovaterc.json5
 license-header        (built-in)          not configured  fast      no   Check source files have the required license header
 "#
         );

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -26,6 +26,12 @@ const GOFMT_URL: &str = "https://pkg.go.dev/cmd/gofmt";
 const GOLANGCI_LINT_URL: &str = "https://golangci-lint.run/";
 const GOLANGCI_LINT_CONFIG_URL: &str = "https://golangci-lint.run/usage/configuration/";
 const GOOGLE_JAVA_FORMAT_URL: &str = "https://github.com/google/google-java-format";
+const CHECKSTYLE_URL: &str = "https://github.com/checkstyle/checkstyle";
+const CHECKSTYLE_CONFIG_URL: &str = "https://checkstyle.org/config.html";
+const DOTENV_LINTER_URL: &str = "https://github.com/dotenv-linter/dotenv-linter";
+const DOTENV_LINTER_CONFIG_URL: &str = "https://dotenv-linter.github.io/";
+const KUBE_LINTER_URL: &str = "https://github.com/stackrox/kube-linter";
+const KUBE_LINTER_CONFIG_URL: &str = "https://docs.kubelinter.io/";
 const HADOLINT_URL: &str = "https://github.com/hadolint/hadolint";
 const HADOLINT_CONFIG_URL: &str =
     "https://github.com/hadolint/hadolint?tab=readme-ov-file#configure";
@@ -52,6 +58,19 @@ const TYPOS_CONFIG_URL: &str = "https://github.com/crate-ci/typos/blob/master/do
 const XMLLINT_URL: &str = "https://github.com/jonwiggins/xmloxide";
 const YAMLLINT_CONFIG_URL: &str = "https://yamllint.readthedocs.io/en/stable/configuration.html";
 const RYL_URL: &str = "https://github.com/owenlamont/ryl";
+
+const CHECKSTYLE_TOOL_KEY: &str =
+    "github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]";
+const KUBE_LINTER_PATTERNS: &[&str] = &[
+    "k8s/*.yml",
+    "k8s/*.yaml",
+    "kubernetes/*.yml",
+    "kubernetes/*.yaml",
+    "manifests/*.yml",
+    "manifests/*.yaml",
+];
+const CHECKSTYLE_BASELINE_TRIGGERS: &[ConfigFile] =
+    &[ConfigFile::project("checkstyle-suppressions.xml")];
 
 const SHELLCHECK_UNSUPPORTED_CONFIGS: &[ConfigFile] = &[
     ConfigFile::config_dir("shellcheckrc"),
@@ -224,6 +243,36 @@ fn check_yaml_lint() -> Check {
         .migrate_tool_keys(&["cargo:yaml-lint", "github:owenlamont/ryl"])
 }
 
+fn check_kube_linter() -> Check {
+    Check::native(&crate::linters::kube_linter::CHECK_TYPE)
+        .patterns(KUBE_LINTER_PATTERNS)
+        .mise_tool("aqua:stackrox/kube-linter")
+        .baseline_config(ConfigFile::config_dir("kube-linter.yaml"))
+        .project_url(KUBE_LINTER_URL)
+        .config_doc_url(KUBE_LINTER_CONFIG_URL)
+        .overview(
+            OverviewSection::ToolingCi,
+            "Kubernetes manifests",
+            OverviewRole::Check,
+            Some("Kubernetes security and production-readiness policy"),
+        )
+        .desc("Lint explicitly selected Kubernetes resources")
+        .docs(
+            "KubeLinter is report-only and only runs on files selected by\
+            \n\
+            [checks.kube-linter].paths (or existing conventional k8s/,\
+            \n\
+            kubernetes/, or manifests/ directories). Flint parses YAML documents\
+            \n\
+            and passes only documents containing apiVersion and kind, so ordinary\
+            \n\
+            YAML and Docker Compose files are not treated as Kubernetes resources.\
+            \n\
+            Helm/Kustomize rendering remains an explicit separate workflow.",
+        )
+        .style()
+}
+
 fn check_taplo() -> Check {
     Check::file(
         "taplo",
@@ -375,6 +424,37 @@ fn check_typos() -> Check {
         .migrate_tool_keys(&["codespell", "pipx:codespell", "aqua:crate-ci/typos"])
         .desc("Check for common spelling mistakes")
         .mise_tool("typos")
+}
+
+fn check_dotenv_linter() -> Check {
+    Check::files(
+        "dotenv-linter",
+        "dotenv-linter check --plain --skip-updates {FILES}",
+        &[".env", ".env.*", "*.env"],
+    )
+    .fix("dotenv-linter fix --plain --no-backup {FILES}")
+    .mise_tool("aqua:dotenv-linter/dotenv-linter")
+    .project_url(DOTENV_LINTER_URL)
+    .config_doc_url(DOTENV_LINTER_CONFIG_URL)
+    .overview(
+        OverviewSection::FilesFormats,
+        "Dotenv",
+        OverviewRole::Both,
+        Some("Environment-file syntax and consistency"),
+    )
+    .desc("Lint dotenv environment files without printing their values")
+    .docs(
+        "Checks only explicit .env-style files: .env, .env.* and files ending in .env.\
+        \n\
+        Flint passes file paths rather than a directory, so an unrelated YAML, Compose,\
+        \n\
+        or application config file is never scanned. Check mode is read-only; fix mode\
+        \n\
+        uses dotenv-linter's no-backup option and remains serialized with other Flint\
+        \n\
+        fixers. Do not commit secret-bearing .env files.",
+    )
+    .style()
 }
 
 fn check_editorconfig_checker() -> Check {
@@ -631,6 +711,46 @@ fn check_google_java_format() -> Check {
     .lang()
 }
 
+fn check_checkstyle() -> Check {
+    Check::files(
+        "checkstyle",
+        "checkstyle -c checkstyle.xml {FILES}",
+        &["*.java"],
+    )
+    .java_jar()
+    .mise_tool(CHECKSTYLE_TOOL_KEY)
+    .baseline_config(ConfigFile::project("checkstyle.xml"))
+    .baseline_triggers(CHECKSTYLE_BASELINE_TRIGGERS)
+    .failure_output_patterns(&["[WARN]", "[ERROR]"])
+    .project_url(CHECKSTYLE_URL)
+    .config_doc_url(CHECKSTYLE_CONFIG_URL)
+    .overview(
+        OverviewSection::Languages,
+        "Java",
+        OverviewRole::Linter,
+        Some("Java coding standard"),
+    )
+    .desc("Check Java source against a repository-owned Checkstyle configuration")
+    .docs(
+        "Runs the standalone Checkstyle CLI against selected Java files.\
+        \n\
+        A Java runtime must be available on PATH because the curated\
+        \n\
+        Checkstyle distribution is a JAR.\
+        \n\
+        The repository must provide checkstyle.xml at its root; a root-level\
+        \n\
+        checkstyle-suppressions.xml is also supported by Checkstyle's normal\
+        \n\
+        property default. Flint does not infer Maven or Gradle source roots,\
+        \n\
+        and Checkstyle is report-only: use a formatter such as\
+        \n\
+        google-java-format for safe formatting fixes.",
+    )
+    .lang()
+}
+
 fn check_ktlint() -> Check {
     Check::files(
         "ktlint",
@@ -834,12 +954,14 @@ pub fn builtin() -> Vec<Check> {
         check_shfmt(),
         check_rumdl(),
         check_yaml_lint(),
+        check_kube_linter(),
         check_taplo(),
         check_actionlint(),
         check_zizmor(),
         check_hadolint(),
         check_xmllint(),
         check_typos(),
+        check_dotenv_linter(),
         check_editorconfig_checker(),
         check_golangci_lint(),
         check_ruff(),
@@ -850,6 +972,7 @@ pub fn builtin() -> Vec<Check> {
         check_cargo_fmt(),
         check_gofmt(),
         check_google_java_format(),
+        check_checkstyle(),
         check_ktlint(),
         check_dotnet_format(),
         check_lychee(),

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -527,6 +527,8 @@ pub struct Check {
     pub status_hook: Option<StatusHook>,
     /// Optional output normalizer used for non-verbose failing process runs.
     pub nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
+    /// Output markers that make an otherwise successful process invocation fail.
+    pub failure_output_patterns: &'static [&'static str],
     /// Optional hint appended when a known toolchain component is missing.
     pub missing_component_hint: Option<MissingComponentHint>,
     /// Additional config-like files that trigger an all-files baseline run when changed.
@@ -550,8 +552,10 @@ pub struct Check {
     /// Toolchain keys stay above the `# Linters` header in `mise.toml` so they're
     /// visually separated from lint-only entries.
     pub toolchain: Option<Option<&'static str>>,
-    /// On Windows, the binary is a self-executing JAR that cannot be run directly
-    /// or via cmd.exe — invoke as `java -jar <resolved-path>` instead.
+    /// The binary is a self-executing JAR that must be invoked as
+    /// `java -jar <resolved-path>` instead of directly.
+    pub java_jar: bool,
+    /// On Windows, invoke this self-executing JAR through `java -jar`.
     pub windows_java_jar: bool,
     /// Extra generated workflow setup needed when this check is selected by `flint init`.
     pub workflow_setup: Option<WorkflowSetup>,
@@ -671,6 +675,7 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -686,6 +691,7 @@ impl Check {
                 full_fix_cmd: "",
                 scope,
             },
+            java_jar: false,
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
@@ -725,6 +731,7 @@ impl Check {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -733,6 +740,7 @@ impl Check {
             activate_unconditionally: false,
             category: Category::Default,
             toolchain: None,
+            java_jar: false,
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
@@ -802,8 +810,14 @@ impl Check {
         self
     }
 
+    /// Invoke this binary via `java -jar <path>` rather than directly.
+    /// Use for self-executing JARs (e.g. ktlint and Checkstyle).
+    pub fn java_jar(mut self) -> Self {
+        self.java_jar = true;
+        self
+    }
+
     /// On Windows, invoke this binary via `java -jar <path>` rather than directly.
-    /// Use for self-executing JARs (e.g. ktlint) that cmd.exe cannot run.
     pub fn windows_java_jar(mut self) -> Self {
         self.windows_java_jar = true;
         self
@@ -1002,6 +1016,11 @@ impl Check {
 
     pub fn nonverbose_failure_output(mut self, hook: NonverboseFailureOutputHook) -> Self {
         self.nonverbose_failure_output = Some(hook);
+        self
+    }
+
+    pub fn failure_output_patterns(mut self, patterns: &'static [&'static str]) -> Self {
+        self.failure_output_patterns = patterns;
         self
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -47,6 +47,7 @@ struct InvocationOutputPolicy<'a> {
     env: &'a [(&'static str, &'static str)],
     nonverbose_filter_prefixes: &'a [&'static str],
     stderr_filter_prefixes: &'a [&'static str],
+    failure_output_patterns: &'a [&'static str],
 }
 
 /// A check with all inputs pre-resolved, ready to execute without borrowing
@@ -56,10 +57,11 @@ enum PreparedCheck {
         name: String,
         argv_list: Vec<Vec<String>>,
         tracked_files: Vec<PathBuf>,
-        windows_java_jar: bool,
+        java_jar: bool,
         env: &'static [(&'static str, &'static str)],
         nonverbose_filter_prefixes: &'static [&'static str],
         stderr_filter_prefixes: &'static [&'static str],
+        failure_output_patterns: &'static [&'static str],
         nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
         missing_component_hint: Option<MissingComponentHint>,
     },
@@ -81,10 +83,11 @@ impl PreparedCheck {
             Self::Invocations {
                 argv_list,
                 tracked_files,
-                windows_java_jar,
+                java_jar,
                 env,
                 nonverbose_filter_prefixes,
                 stderr_filter_prefixes,
+                failure_output_patterns,
                 nonverbose_failure_output,
                 missing_component_hint,
                 ..
@@ -97,7 +100,7 @@ impl PreparedCheck {
                 let out = run_invocations(
                     &name,
                     &argv_list,
-                    windows_java_jar,
+                    java_jar,
                     InvocationOutputPolicy {
                         nonverbose: !verbose,
                         env: if verbose { &[] } else { env },
@@ -107,6 +110,7 @@ impl PreparedCheck {
                             nonverbose_filter_prefixes
                         },
                         stderr_filter_prefixes: if verbose { &[] } else { stderr_filter_prefixes },
+                        failure_output_patterns,
                     },
                     nonverbose_failure_output,
                     missing_component_hint,
@@ -274,10 +278,11 @@ fn prepare(
                 name,
                 argv_list,
                 tracked_files,
-                windows_java_jar: check.windows_java_jar,
+                java_jar: check.java_jar || (cfg!(windows) && check.windows_java_jar),
                 env: check.env,
                 nonverbose_filter_prefixes: check.nonverbose_filter_prefixes,
                 stderr_filter_prefixes: check.stderr_filter_prefixes,
+                failure_output_patterns: check.failure_output_patterns,
                 nonverbose_failure_output: check.nonverbose_failure_output,
                 missing_component_hint: check.missing_component_hint,
             })
@@ -573,7 +578,7 @@ fn render_config_args(config_args: &[String]) -> String {
 async fn run_invocations(
     name: &str,
     invocations: &[Vec<String>],
-    windows_java_jar: bool,
+    java_jar: bool,
     output_policy: InvocationOutputPolicy<'_>,
     nonverbose_failure_output: Option<NonverboseFailureOutputHook>,
     missing_component_hint: Option<MissingComponentHint>,
@@ -587,13 +592,16 @@ async fn run_invocations(
         if argv.is_empty() {
             continue;
         }
-        let mut cmd = crate::linters::spawn_command(argv, windows_java_jar);
+        let mut cmd = crate::linters::spawn_command(argv, java_jar);
         cmd.current_dir(root)
             .stdin(Stdio::null())
             .envs(output_policy.env.iter().copied());
         let result = cmd.output().await;
         match result {
             Ok(out) => {
+                let output_policy_failed =
+                    output_contains_any(&out.stdout, output_policy.failure_output_patterns)
+                        || output_contains_any(&out.stderr, output_policy.failure_output_patterns);
                 if output_policy.nonverbose
                     && !out.status.success()
                     && let Some(normalize) = nonverbose_failure_output
@@ -634,7 +642,7 @@ async fn run_invocations(
                         combined_stderr.extend_from_slice(&stderr);
                     }
                 }
-                if !out.status.success() {
+                if !out.status.success() || output_policy_failed {
                     all_ok = false;
                 }
             }
@@ -654,6 +662,17 @@ async fn run_invocations(
         stderr: combined_stderr,
         setup_outcome: None,
     }
+}
+
+fn output_contains_any(output: &[u8], patterns: &[&str]) -> bool {
+    patterns
+        .iter()
+        .filter(|pattern| !pattern.is_empty())
+        .any(|pattern| {
+            output
+                .windows(pattern.len())
+                .any(|window| window == pattern.as_bytes())
+        })
 }
 
 fn filter_stderr_lines(stderr: &[u8], prefixes: &[&str]) -> Vec<u8> {
@@ -921,6 +940,7 @@ mod tests {
             adaptive_relevance: None,
             status_hook: None,
             nonverbose_failure_output: None,
+            failure_output_patterns: &[],
             missing_component_hint: None,
             baseline_triggers: &[],
             is_formatter: false,
@@ -929,6 +949,7 @@ mod tests {
             activate_unconditionally: false,
             category: Category::Default,
             toolchain: None,
+            java_jar: false,
             windows_java_jar: false,
             workflow_setup: None,
             fix_behavior: crate::registry::FixBehavior::Definitive,
@@ -959,6 +980,17 @@ mod tests {
             },
             ..project_check(patterns)
         }
+    }
+
+    #[test]
+    fn failure_output_patterns_match_stdout_and_stderr() {
+        assert!(output_contains_any(b"[WARN] violation\n", &["[WARN]"]));
+        assert!(output_contains_any(
+            b"error: [WARN] violation\n",
+            &["[WARN]"]
+        ));
+        assert!(!output_contains_any(b"clean\n", &["[WARN]"]));
+        assert!(!output_contains_any(b"anything\n", &[""]));
     }
 
     #[test]

--- a/tests/cases/checkstyle/clean/files/Foo.java
+++ b/tests/cases/checkstyle/clean/files/Foo.java
@@ -1,0 +1,1 @@
+class Foo {}

--- a/tests/cases/checkstyle/clean/files/checkstyle.xml
+++ b/tests/cases/checkstyle/clean/files/checkstyle.xml
@@ -1,0 +1,1 @@
+<module name="Checker"/>

--- a/tests/cases/checkstyle/clean/files/mise.toml
+++ b/tests/cases/checkstyle/clean/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]" = "checkstyle-13.8.0"

--- a/tests/cases/checkstyle/clean/test.toml
+++ b/tests/cases/checkstyle/clean/test.toml
@@ -1,0 +1,13 @@
+[expected]
+args = "run --full checkstyle"
+exit = 0
+
+[fake_bins]
+checkstyle = '''
+#!/bin/sh
+exit 0
+'''
+java = '''
+#!/bin/sh
+exit 0
+'''

--- a/tests/cases/checkstyle/missing-config/files/Foo.java
+++ b/tests/cases/checkstyle/missing-config/files/Foo.java
@@ -1,0 +1,1 @@
+class Foo {}

--- a/tests/cases/checkstyle/missing-config/files/mise.toml
+++ b/tests/cases/checkstyle/missing-config/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]" = "checkstyle-13.8.0"

--- a/tests/cases/checkstyle/missing-config/test.toml
+++ b/tests/cases/checkstyle/missing-config/test.toml
@@ -1,0 +1,21 @@
+[expected]
+args = "run --full checkstyle"
+exit = 1
+stderr = '''
+[checkstyle]
+Could not find config XML file 'checkstyle.xml'.
+
+flint: 1 check failed (checkstyle)
+💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
+'''
+
+[fake_bins]
+checkstyle = '''
+#!/bin/sh
+exit 0
+'''
+java = '''
+#!/bin/sh
+printf "Could not find config XML file 'checkstyle.xml'.\\n"
+exit 1
+'''

--- a/tests/cases/checkstyle/warning/files/Foo.java
+++ b/tests/cases/checkstyle/warning/files/Foo.java
@@ -1,0 +1,1 @@
+class Foo {}

--- a/tests/cases/checkstyle/warning/files/checkstyle.xml
+++ b/tests/cases/checkstyle/warning/files/checkstyle.xml
@@ -1,0 +1,1 @@
+<module name="Checker"/>

--- a/tests/cases/checkstyle/warning/files/mise.toml
+++ b/tests/cases/checkstyle/warning/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"github:checkstyle/checkstyle[matching=all.jar,rename_exe=checkstyle]" = "checkstyle-13.8.0"

--- a/tests/cases/checkstyle/warning/test.toml
+++ b/tests/cases/checkstyle/warning/test.toml
@@ -1,0 +1,20 @@
+[expected]
+args = "run --full checkstyle"
+exit = 1
+stderr = '''
+[checkstyle]
+[WARN] Foo.java:1: warning\n
+flint: 1 check failed (checkstyle)
+💡 Try `flint run --fix` to auto-fix lint issues, then re-run `flint run` to verify.
+'''
+
+[fake_bins]
+checkstyle = '''
+#!/bin/sh
+exit 0
+'''
+java = '''
+#!/bin/sh
+printf '[WARN] Foo.java:1: warning\\n'
+exit 0
+'''

--- a/tests/cases/dotenv-linter/auto-fix/files/.env
+++ b/tests/cases/dotenv-linter/auto-fix/files/.env
@@ -1,0 +1,1 @@
+bad line

--- a/tests/cases/dotenv-linter/auto-fix/files/mise.toml
+++ b/tests/cases/dotenv-linter/auto-fix/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"aqua:dotenv-linter/dotenv-linter" = "4.0.0"

--- a/tests/cases/dotenv-linter/auto-fix/test.toml
+++ b/tests/cases/dotenv-linter/auto-fix/test.toml
@@ -1,0 +1,20 @@
+[expected]
+args = "run --full --fix dotenv-linter"
+exit = 1
+stderr = '''
+flint: fixed: dotenv-linter — commit before pushing
+'''
+
+[expected.files]
+".env" = "PORT=8080\n"
+
+[fake_bins]
+dotenv-linter = '''
+#!/bin/sh
+set -eu
+case "$1" in
+  check) exit 1 ;;
+  fix) printf 'PORT=8080\n' > .env ;;
+  *) exit 1 ;;
+esac
+'''

--- a/tests/cases/dotenv-linter/clean/files/.env
+++ b/tests/cases/dotenv-linter/clean/files/.env
@@ -1,0 +1,2 @@
+PORT=8080
+NAME="flint"

--- a/tests/cases/dotenv-linter/clean/files/mise.toml
+++ b/tests/cases/dotenv-linter/clean/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"aqua:dotenv-linter/dotenv-linter" = "4.0.0"

--- a/tests/cases/dotenv-linter/clean/test.toml
+++ b/tests/cases/dotenv-linter/clean/test.toml
@@ -1,0 +1,13 @@
+[expected]
+args = "run --full dotenv-linter"
+exit = 0
+
+[fake_bins]
+dotenv-linter = '''
+#!/bin/sh
+set -eu
+case "$1" in
+  check) exit 0 ;;
+  *) echo "unexpected command: $*" >&2; exit 1 ;;
+esac
+'''

--- a/tests/cases/kube-linter/selection/files/compose.yaml
+++ b/tests/cases/kube-linter/selection/files/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  app:
+    image: example/app

--- a/tests/cases/kube-linter/selection/files/k8s/deployment.yaml
+++ b/tests/cases/kube-linter/selection/files/k8s/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flint

--- a/tests/cases/kube-linter/selection/files/mise.toml
+++ b/tests/cases/kube-linter/selection/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"aqua:stackrox/kube-linter" = "0.8.3"

--- a/tests/cases/kube-linter/selection/test.toml
+++ b/tests/cases/kube-linter/selection/test.toml
@@ -1,0 +1,13 @@
+[expected]
+args = "run --full kube-linter"
+exit = 0
+
+[expected.files]
+".kube-linter-args" = "lint k8s/deployment.yaml\n"
+
+[fake_bins]
+kube-linter = '''
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" > .kube-linter-args
+'''


### PR DESCRIPTION
Blocked by https://github.com/grafana/flint/pull/429

## Summary

- add standalone Checkstyle support using the curated JAR and Java runtime
- add safe dotenv-linter checking and fixing
- add report-only kube-linter support for selected Kubernetes manifests
- add tool pins, generated docs, and focused end-to-end cases

Stacked on the mise registry compatibility PR. This PR does not change a consumer repository yet.

## Validation

- `cargo fmt --all -- --check`
- `mise exec -- cargo clippy --all-targets -- -D warnings`
- `mise exec -- cargo test --bin flint` (293 passed; local test used a temporary no-op `dotnet` executable)
- `FLINT_CASES=checkstyle cargo test -q --test e2e cases`
- `FLINT_CASES=dotenv-linter cargo test -q --test e2e cases`
- `FLINT_CASES=kube-linter cargo test -q --test e2e cases`
- `mise run generate`
- `mise run lint:fix`
