### PR TITLE
fix(renovate): avoid overlapping mise managers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,6 +55,13 @@
   ],
   packageRules: [
     {
+      description: "Prefer Flint's checksum-aware mise manager over Renovate's native uses-with manager",
+      matchManagers: ["github-actions"],
+      matchDepTypes: ["uses-with"],
+      matchPackageNames: ["jdx/mise"],
+      enabled: false,
+    },
+    {
       matchDepNames: [
         "actionlint",
         "aqua:jonwiggins/xmloxide",

--- a/default.json
+++ b/default.json
@@ -19,6 +19,13 @@
   ],
   "packageRules": [
     {
+      "description": "Prefer Flint's checksum-aware mise manager over Renovate's native uses-with manager",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["uses-with"],
+      "matchPackageNames": ["jdx/mise"],
+      "enabled": false
+    },
+    {
       "matchDepNames": [
         "actionlint",
         "aqua:jonwiggins/xmloxide",

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -571,6 +571,26 @@ fn repo_renovate_config_stays_aligned_with_shared_preset_contract() {
     }
 
     {
+        let description =
+            "Prefer Flint's checksum-aware mise manager over Renovate's native uses-with manager";
+        let default_rule = package_rule_by_description(&default_parsed, description)
+            .unwrap_or_else(|| panic!("default.json missing package rule {description:?}"));
+        let repo_rule =
+            package_rule_by_description(&repo_parsed, description).unwrap_or_else(|| {
+                panic!(".github/renovate.json5 missing package rule {description:?}")
+            });
+        assert_eq!(
+            default_rule, repo_rule,
+            "mise uses-with fallback rule drifted between default.json and .github/renovate.json5"
+        );
+        assert_eq!(
+            default_rule["enabled"].as_bool(),
+            Some(false),
+            "mise uses-with fallback rule must disable Renovate's overlapping native manager"
+        );
+    }
+
+    {
         let description = "Update mise version in GitHub Actions workflows";
         let default_manager = custom_manager_by_description(&default_parsed, description)
             .unwrap_or_else(|| panic!("default.json missing custom manager {description:?}"));


### PR DESCRIPTION
## Summary

- disable Renovate's native `github-actions` `uses-with` dependency for `jdx/mise` in Flint's shared preset
- retain Flint's checksum-aware custom manager as the single owner of `jdx/mise-action` version and checksum updates
- mirror the fallback in Flint's own Renovate config and test that the two rules stay aligned

## Why

Renovate 43.266.0 added native support for `jdx/mise-action`'s `with.version`, but it does not yet extract `with.sha256`. When both the native manager and Flint's custom manager update the same stanza, the version-only edit can win and leave an invalid checksum, as seen in https://github.com/grafana/oats/pull/444.

An upstream follow-up is being proposed to add checksum support. This rule is the consumer-side fallback until that support is released and adopted.

## Validation

- `cargo test repo_renovate_config_stays_aligned_with_shared_preset_contract -- --nocapture`
- `mise run lint:fix`
