### PR TITLE
ci: limit release builds to Rust toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       attestations: write
     env:
       TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      MISE_ENABLE_TOOLS: rust
 
     strategy:
       fail-fast: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,17 @@ Run tests with `cargo test`. Tests spin up temporary git
 repos and run the real `flint` binary — they are
 integration tests, not unit tests, so they can be slow.
 
+For focused GitHub Actions jobs, set job-level
+`MISE_ENABLE_TOOLS` to the complete mise tool allowlist.
+Artifact release jobs must set `cache: false`. For other
+jobs that keep mise-action caching enabled, extend its cache
+key with `-{{env.MISE_ENABLE_TOOLS}}`, because the default
+key does not include this setting:
+
+```yaml
+cache_key: "{{default}}-{{env.MISE_ENABLE_TOOLS}}"
+```
+
 The `cases` test runs all fixture cases under `tests/cases/`
 in parallel by top-level directory (linter group). Two env
 vars control its behaviour:


### PR DESCRIPTION
## What changed

- Restrict mise to the Rust toolchain in the release-assets build job with `MISE_ENABLE_TOOLS: rust`.
- Document the focused-job allowlist, release cache policy, and cache-key rule for non-release jobs.

## Why

The v0.22.10 Windows release build invoked mise's shim and attempted to install every tool declared in `mise.toml`. Repeated GitHub API timeouts while resolving unrelated linters prevented Cargo from running and left the release in draft state without Windows assets.

This follows the targeted-tool pattern already used by the release management workflow. Cross-compilation remains installed separately by `taiki-e/install-action`, and artifact release caching remains disabled.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `git diff --check`
- Recovery release workflow completed successfully for v0.22.10
