### PR TITLE
docs: explain release mise isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       attestations: write
     env:
       TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-      # Keep artifact releases isolated from unrelated mise tools and caches.
+      # Artifact releases pair a focused tool allowlist with cache: false.
       MISE_ENABLE_TOOLS: rust
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       attestations: write
     env:
       TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      # Keep artifact releases isolated from unrelated mise tools and caches.
       MISE_ENABLE_TOOLS: rust
 
     strategy:


### PR DESCRIPTION
## What changed

- Explain the release-specific mise allowlist and no-cache policy directly beside `MISE_ENABLE_TOOLS`.

## Why

The point-of-use comment is visible to both maintainers and agents when they edit or copy the workflow, without requiring them to discover separate repository instructions.

## Validation

- `mise run lint:fix`
- `git diff --check`
