### PR TITLE
fix(java): order formatting after regex replacements

### DIFF
--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -626,7 +626,6 @@ fn check_gofmt() -> Check {
 fn check_google_java_format() -> Check {
     Check::native(&google_java_format::CHECK_TYPE)
         .patterns(&["*.java"])
-        .fix_after("regex-replace")
         .mise_tool("google-java-format")
         .formatter()
         .editorconfig_line_length_off(
@@ -651,6 +650,7 @@ fn check_google_java_format() -> Check {
 
 fn check_regex_replace() -> Check {
     Check::native(&regex_replace::CHECK_TYPE)
+        .fix_first()
         .activate_unconditionally()
         .status_hook(regex_replace::status)
         .desc("Apply configured regular-expression replacements to source files")

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -626,6 +626,7 @@ fn check_gofmt() -> Check {
 fn check_google_java_format() -> Check {
     Check::native(&google_java_format::CHECK_TYPE)
         .patterns(&["*.java"])
+        .fix_after("regex-replace")
         .mise_tool("google-java-format")
         .formatter()
         .editorconfig_line_length_off(

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -133,6 +133,16 @@ fn registry_entries_have_complete_metadata() {
 }
 
 #[test]
+fn google_java_format_fixes_after_regex_replace() {
+    let check = builtin()
+        .into_iter()
+        .find(|check| check.name == "google-java-format")
+        .unwrap();
+
+    assert_eq!(check.fix_after, vec!["regex-replace"]);
+}
+
+#[test]
 fn fixer_dependencies_are_valid_and_acyclic() {
     let registry = builtin();
     let fixers: Vec<&Check> = registry.iter().filter(|check| check.has_fix()).collect();

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -328,7 +328,7 @@ fn names_prefer_binary_or_native_command() {
 }
 
 #[test]
-fn test_case_groups_match_registered_checks() {
+fn case_directories_match_registry() {
     let cases_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/cases");
     let mut allowed: BTreeSet<String> = builtin()
         .into_iter()

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -133,13 +133,13 @@ fn registry_entries_have_complete_metadata() {
 }
 
 #[test]
-fn google_java_format_fixes_after_regex_replace() {
+fn regex_replace_fixes_before_all_other_checks() {
     let check = builtin()
         .into_iter()
-        .find(|check| check.name == "google-java-format")
+        .find(|check| check.name == "regex-replace")
         .unwrap();
 
-    assert_eq!(check.fix_after, vec!["regex-replace"]);
+    assert!(check.fix_first);
 }
 
 #[test]

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -557,7 +557,7 @@ pub struct Check {
     /// Extra generated workflow setup needed when this check is selected by `flint init`.
     pub workflow_setup: Option<WorkflowSetup>,
     pub fix_behavior: FixBehavior,
-    /// Run this check before all others in fix mode.
+    /// Run this check before other checks in the same fix pass (runner invocation).
     pub fix_first: bool,
     /// Fixers that must complete before this check runs in fix mode.
     pub fix_after: Vec<&'static str>,

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -557,6 +557,8 @@ pub struct Check {
     /// Extra generated workflow setup needed when this check is selected by `flint init`.
     pub workflow_setup: Option<WorkflowSetup>,
     pub fix_behavior: FixBehavior,
+    /// Run this check before all others in fix mode.
+    pub fix_first: bool,
     /// Fixers that must complete before this check runs in fix mode.
     pub fix_after: Vec<&'static str>,
     pub kind: CheckKind,
@@ -718,6 +720,7 @@ impl Check {
             java_jar: None,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
+            fix_first: false,
             fix_after: vec![],
             desc: "",
             project_url: None,
@@ -765,6 +768,7 @@ impl Check {
             java_jar: None,
             workflow_setup: None,
             fix_behavior: FixBehavior::Definitive,
+            fix_first: false,
             fix_after: vec![],
             kind: CheckKind::Native(NativeCheckRef::new(native)),
             desc: "",
@@ -859,6 +863,12 @@ impl Check {
     /// Run this fixer after the named fixer when both are active.
     pub fn fix_after(mut self, check: &'static str) -> Self {
         self.fix_after.push(check);
+        self
+    }
+
+    /// Run this check before all other checks in fix mode.
+    pub fn fix_first(mut self) -> Self {
+        self.fix_first = true;
         self
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -227,6 +227,7 @@ pub async fn run(
 
 fn order_checks_for_fix<'a>(checks: &[&'a Check]) -> Result<Vec<&'a Check>> {
     let mut remaining = checks.to_vec();
+    remaining.sort_by_key(|check| !check.fix_first);
     let mut ordered = Vec::with_capacity(remaining.len());
 
     while !remaining.is_empty() {
@@ -954,6 +955,7 @@ mod tests {
             java_jar: None,
             workflow_setup: None,
             fix_behavior: crate::registry::FixBehavior::Definitive,
+            fix_first: false,
             fix_after: vec![],
             kind: CheckKind::Template {
                 check_cmd: "run-it",
@@ -1005,6 +1007,21 @@ mod tests {
         assert_eq!(
             ordered.iter().map(|check| check.name).collect::<Vec<_>>(),
             ["first", "second"]
+        );
+    }
+
+    #[test]
+    fn fix_order_runs_fix_first_checks_before_all_others() {
+        let mut regular = project_check(&[]);
+        regular.name = "regular";
+        let mut first = project_check(&[]);
+        first.name = "first";
+        first.fix_first = true;
+
+        let ordered = order_checks_for_fix(&[&regular, &first]).unwrap();
+        assert_eq!(
+            ordered.iter().map(|check| check.name).collect::<Vec<_>>(),
+            ["first", "regular"]
         );
     }
 


### PR DESCRIPTION
## Summary

- declare that `google-java-format` fixes run after `regex-replace`
- add a registry regression test for the dependency

## Why

Flint currently converges in a single fix pass only because `regex-replace` happens to precede `google-java-format` in the built-in registry. Making the dependency explicit preserves the intended order if the registry is reorganized, so replacements that add static imports are subsequently normalized by google-java-format.

This follows up on [review feedback in open-telemetry/opentelemetry-java-instrumentation#19242](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19242#discussion_r3677971975).

## Validation

- `mise run lint:fix`
- `mise run test` (309 unit tests and 11 passing integration tests; 1 integration test ignored)
