### PR TITLE
docs: add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,4 @@ flint: fixed: gofmt — commit before pushing
 flint: fixed: cargo-fmt — commit before pushing | review: shellcheck
 flint: fixed: gofmt — commit before pushing | partial: cargo-clippy
 ```
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,4 +142,5 @@ flint: fixed: gofmt — commit before pushing
 flint: fixed: cargo-fmt — commit before pushing | review: shellcheck
 flint: fixed: gofmt — commit before pushing | partial: cargo-clippy
 ```
+
 - Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
