### PR TITLE
feat: track GitHub Action ref metadata

### DIFF
--- a/docs/linters/renovate-deps.md
+++ b/docs/linters/renovate-deps.md
@@ -163,6 +163,8 @@ It stores only the stable metadata Flint needs for these checks:
 
 - `files`: extracted dependency names by file and manager
 - `meta`: stable package metadata used for rule-coverage validation
+- `actionMeta`: stable identity and ref-shape metadata for reusable GitHub
+  Actions, keyed by the complete `package/path` target
 
 Lookup-only fields such as `currentVersion`, `currentValue`, and
 `extractVersion` are used transiently during validation and autofix, but are
@@ -180,6 +182,16 @@ flint run --fix renovate-deps
 Verification (plain `flint run`) uses Renovate's cheap `--dry-run=extract`
 plus the committed snapshot's metadata. `--fix` regenerates via
 `--dry-run=lookup` so meta is authoritative.
+
+For monorepo GitHub Actions, `actionMeta` keeps the action path separate from
+the shared package name. Semver-like refs record their optional compatibility
+prefix (for example, `create-github-app-token/v0.2.2` records compatibility
+`create-github-app-token`, while `v0.2.2` records no prefix), and branch refs
+record the ref (for example, `main`). Comparing these shapes catches a
+namespace change without changing the snapshot for ordinary version bumps in
+the same namespace. Lookup remains responsible for transient ref-to-commit
+and digest checks; the stable snapshot does not contain a digest that would
+change on every update.
 
 When Flint can infer a better `extractVersion` directly from Renovate's
 resolved `currentVersion` and `currentValue`, `--fix` also appends a targeted

--- a/src/linters/renovate_deps/action_validation.rs
+++ b/src/linters/renovate_deps/action_validation.rs
@@ -1,0 +1,68 @@
+use super::snapshot::canonical_manager_name;
+
+/// Reject deterministic GitHub Action digest lookup failures while leaving
+/// transient lookup failures inconclusive.
+pub(crate) fn validate_lookup_action_warnings(
+    log_bytes: &[u8],
+    exclude_managers: &[String],
+) -> anyhow::Result<()> {
+    const DETERMINISTIC: &str = "Could not determine new digest for update";
+
+    if exclude_managers
+        .iter()
+        .map(|manager| canonical_manager_name(manager))
+        .any(|manager| manager == "github-actions")
+    {
+        return Ok(());
+    }
+
+    for line in std::str::from_utf8(log_bytes)?.lines() {
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if !entry
+            .get("msg")
+            .and_then(|value| value.as_str())
+            .is_some_and(|msg| msg == "packageFiles with updates")
+        {
+            continue;
+        }
+        let Some(package_files) = entry
+            .get("packageFiles")
+            .or_else(|| entry.get("config"))
+            .and_then(|value| value.get("github-actions"))
+            .and_then(|value| value.as_array())
+        else {
+            continue;
+        };
+        for package_file in package_files {
+            let Some(deps) = package_file.get("deps").and_then(|value| value.as_array()) else {
+                continue;
+            };
+            for dep in deps {
+                let Some(warnings) = dep.get("warnings").and_then(|value| value.as_array()) else {
+                    continue;
+                };
+                for warning in warnings {
+                    let Some(message) = warning.get("message").and_then(|value| value.as_str())
+                    else {
+                        continue;
+                    };
+                    if !message.starts_with(DETERMINISTIC) {
+                        continue;
+                    }
+                    let dep_name = dep
+                        .get("depName")
+                        .or_else(|| dep.get("packageName"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("unknown dependency");
+                    anyhow::bail!(
+                        "Renovate reported an invalid GitHub Action ref for {dep_name}: {message}"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -11,7 +11,9 @@ use self::rules::{
     incomplete_meta_for_rules, trim_snapshot_meta, validate_extract_version_consistency,
     validate_rule_coverage,
 };
-use self::snapshot::{Snapshot, extract_deps, read_snapshot, unified_diff, write_snapshot};
+use self::snapshot::{
+    Snapshot, canonical_manager_name, extract_deps, read_snapshot, unified_diff, write_snapshot,
+};
 use crate::config::RenovateDepsConfig;
 use crate::files::FileList;
 use crate::linters::LinterOutput;
@@ -663,6 +665,9 @@ async fn generate_snapshot(
     let mut generated = Snapshot::default();
     for attempt in 1..=3u32 {
         let log_bytes = run_renovate(project_root, config_path, dry_run).await?;
+        if dry_run == "lookup" {
+            validate_lookup_action_warnings(&log_bytes, exclude_managers)?;
+        }
         generated = extract_deps(&log_bytes, exclude_managers)?;
         if !generated.is_empty() || attempt == 3 {
             break;
@@ -670,6 +675,75 @@ async fn generate_snapshot(
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     }
     Ok(generated)
+}
+
+/// Renovate normally exits successfully even when a digest lookup cannot be
+/// completed. A missing digest for a GitHub Action is actionable when
+/// Renovate reports its deterministic error, but `no-result`, authentication,
+/// and network failures are inconclusive and must not make lint flaky.
+fn validate_lookup_action_warnings(
+    log_bytes: &[u8],
+    exclude_managers: &[String],
+) -> anyhow::Result<()> {
+    const DETERMINISTIC: &str = "Could not determine new digest for update";
+
+    if exclude_managers
+        .iter()
+        .map(|manager| canonical_manager_name(manager))
+        .any(|manager| manager == "github-actions")
+    {
+        return Ok(());
+    }
+
+    for line in std::str::from_utf8(log_bytes)?.lines() {
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if !entry
+            .get("msg")
+            .and_then(|value| value.as_str())
+            .is_some_and(|msg| msg == "packageFiles with updates")
+        {
+            continue;
+        }
+        let Some(package_files) = entry
+            .get("packageFiles")
+            .or_else(|| entry.get("config"))
+            .and_then(|value| value.get("github-actions"))
+            .and_then(|value| value.as_array())
+        else {
+            continue;
+        };
+        for package_file in package_files {
+            let Some(deps) = package_file.get("deps").and_then(|value| value.as_array()) else {
+                continue;
+            };
+            for dep in deps {
+                let Some(warnings) = dep.get("warnings").and_then(|value| value.as_array()) else {
+                    continue;
+                };
+                for warning in warnings {
+                    let Some(message) = warning.get("message").and_then(|value| value.as_str())
+                    else {
+                        continue;
+                    };
+                    if !message.starts_with(DETERMINISTIC) {
+                        continue;
+                    }
+                    let dep_name = dep
+                        .get("depName")
+                        .or_else(|| dep.get("packageName"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("unknown dependency");
+                    anyhow::bail!(
+                        "Renovate reported an invalid GitHub Action ref for {dep_name}: {message}"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Runs `renovate --platform=local` and returns the combined stdout+stderr log bytes.

--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use self::action_validation::validate_lookup_action_warnings;
 use self::install_patch::configure_extract_workaround_env;
 use self::manager_patterns::changed_matches_manager_file_patterns;
 use self::mise_normalize::patch_semver_equivalent_mise_values;
@@ -11,9 +12,7 @@ use self::rules::{
     incomplete_meta_for_rules, trim_snapshot_meta, validate_extract_version_consistency,
     validate_rule_coverage,
 };
-use self::snapshot::{
-    Snapshot, canonical_manager_name, extract_deps, read_snapshot, unified_diff, write_snapshot,
-};
+use self::snapshot::{Snapshot, extract_deps, read_snapshot, unified_diff, write_snapshot};
 use crate::config::RenovateDepsConfig;
 use crate::files::FileList;
 use crate::linters::LinterOutput;
@@ -23,6 +22,7 @@ use crate::registry::{
     NativeRunContext, NativeRunFuture, PreparedNativeCheck,
 };
 
+mod action_validation;
 mod install_patch;
 mod manager_patterns;
 mod mise_normalize;
@@ -675,75 +675,6 @@ async fn generate_snapshot(
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     }
     Ok(generated)
-}
-
-/// Renovate normally exits successfully even when a digest lookup cannot be
-/// completed. A missing digest for a GitHub Action is actionable when
-/// Renovate reports its deterministic error, but `no-result`, authentication,
-/// and network failures are inconclusive and must not make lint flaky.
-fn validate_lookup_action_warnings(
-    log_bytes: &[u8],
-    exclude_managers: &[String],
-) -> anyhow::Result<()> {
-    const DETERMINISTIC: &str = "Could not determine new digest for update";
-
-    if exclude_managers
-        .iter()
-        .map(|manager| canonical_manager_name(manager))
-        .any(|manager| manager == "github-actions")
-    {
-        return Ok(());
-    }
-
-    for line in std::str::from_utf8(log_bytes)?.lines() {
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if !entry
-            .get("msg")
-            .and_then(|value| value.as_str())
-            .is_some_and(|msg| msg == "packageFiles with updates")
-        {
-            continue;
-        }
-        let Some(package_files) = entry
-            .get("packageFiles")
-            .or_else(|| entry.get("config"))
-            .and_then(|value| value.get("github-actions"))
-            .and_then(|value| value.as_array())
-        else {
-            continue;
-        };
-        for package_file in package_files {
-            let Some(deps) = package_file.get("deps").and_then(|value| value.as_array()) else {
-                continue;
-            };
-            for dep in deps {
-                let Some(warnings) = dep.get("warnings").and_then(|value| value.as_array()) else {
-                    continue;
-                };
-                for warning in warnings {
-                    let Some(message) = warning.get("message").and_then(|value| value.as_str())
-                    else {
-                        continue;
-                    };
-                    if !message.starts_with(DETERMINISTIC) {
-                        continue;
-                    }
-                    let dep_name = dep
-                        .get("depName")
-                        .or_else(|| dep.get("packageName"))
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("unknown dependency");
-                    anyhow::bail!(
-                        "Renovate reported an invalid GitHub Action ref for {dep_name}: {message}"
-                    );
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 /// Runs `renovate --platform=local` and returns the combined stdout+stderr log bytes.

--- a/src/linters/renovate_deps/snapshot.rs
+++ b/src/linters/renovate_deps/snapshot.rs
@@ -18,6 +18,26 @@ pub(crate) type DepFiles = BTreeMap<String, BTreeMap<String, Vec<String>>>;
 pub(crate) struct Snapshot {
     pub(crate) meta: BTreeMap<String, DepMeta>,
     pub(crate) files: DepFiles,
+    /// Stable identity and ref-shape metadata for reusable GitHub Actions.
+    ///
+    /// This is deliberately separate from `meta`: Renovate uses the same
+    /// package name for every path in a monorepo, while each action path may
+    /// have its own tag namespace (or be a branch-pinned workflow).
+    #[serde(rename = "actionMeta")]
+    pub(crate) action_meta: BTreeMap<String, ActionMeta>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct ActionMeta {
+    #[serde(rename = "packageName")]
+    pub(crate) package_name: String,
+    #[serde(rename = "refKind")]
+    pub(crate) ref_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) compatibility: Option<String>,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub(crate) ref_: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +99,7 @@ pub(crate) fn read_snapshot(contents: &str) -> anyhow::Result<Snapshot> {
         Snapshot {
             meta: BTreeMap::new(),
             files: serde_json::from_value(parsed)?,
+            action_meta: BTreeMap::new(),
         }
     };
     snapshot.normalize();
@@ -124,6 +145,7 @@ pub(crate) fn extract_deps(
 
     let mut deps_by_file: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> = BTreeMap::new();
     let mut meta_by_dep: BTreeMap<String, DepMetaAccumulator> = BTreeMap::new();
+    let mut action_meta = BTreeMap::new();
 
     if let Some(obj) = config.as_object() {
         for (manager, manager_files) in obj {
@@ -173,6 +195,19 @@ pub(crate) fn extract_deps(
                             .and_then(|v| v.as_str())
                             .map(ToOwned::to_owned),
                     };
+                    if manager == "github-actions"
+                        && let Some(next_action) = action_meta_from_dep(dep)?
+                        && let Some(previous) =
+                            action_meta.insert(next_action.0.clone(), next_action.1.clone())
+                        && previous != next_action.1
+                    {
+                        anyhow::bail!(
+                            "GitHub Action {} has conflicting stable metadata: {:?} vs {:?}",
+                            next_action.0,
+                            previous,
+                            next_action.1
+                        );
+                    }
                     meta_by_dep
                         .entry(dep_name.to_string())
                         .or_default()
@@ -205,10 +240,148 @@ pub(crate) fn extract_deps(
         .map(|(dep_name, meta)| (dep_name, meta.finish()))
         .collect();
 
-    Ok(Snapshot { meta, files })
+    Ok(Snapshot {
+        meta,
+        files,
+        action_meta,
+    })
 }
 
-fn canonical_manager_name(manager: &str) -> &str {
+/// Extract stable metadata for a reusable action from Renovate's dependency
+/// record. The github-actions manager keeps the action sub-path in
+/// `replaceString`, while `depName` remains the repository name. Tracking the
+/// complete target prevents paths in a monorepo from collapsing together.
+fn action_meta_from_dep(dep: &serde_json::Value) -> anyhow::Result<Option<(String, ActionMeta)>> {
+    let package_name = dep
+        .get("packageName")
+        .and_then(|v| v.as_str())
+        .or_else(|| dep.get("depName").and_then(|v| v.as_str()));
+    let Some(package_name) = package_name else {
+        return Ok(None);
+    };
+    let Some(replace_string) = dep.get("replaceString").and_then(|v| v.as_str()) else {
+        return Ok(None);
+    };
+
+    // replaceString is the source fragment, e.g.
+    // `grafana/shared-workflows/actions/create-github-app-token@<sha> # ...`.
+    let target = replace_string
+        .split('@')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .trim_matches(['"', '\'']);
+    let path = target
+        .strip_prefix(&format!("{package_name}/"))
+        .unwrap_or_else(|| if target == package_name { "" } else { target });
+    if path == target && target != package_name {
+        // The source fragment is not the package Renovate extracted (for
+        // example a registry alias); do not invent an action identity.
+        return Ok(None);
+    }
+
+    let current_ref = dep
+        .get("currentValue")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            replace_string
+                .split('@')
+                .nth(1)
+                .and_then(|value| value.split_whitespace().next())
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(current_ref) = current_ref else {
+        return Ok(None);
+    };
+    // A full SHA without a Renovate tag/comment gives us no stable namespace
+    // to validate. Lookup still validates the digest itself.
+    if is_sha(current_ref) {
+        return Ok(None);
+    }
+
+    let target_key = if path.is_empty() {
+        package_name.to_string()
+    } else {
+        format!("{package_name}/{path}")
+    };
+
+    // Do not infer a namespace from the action path: repositories are free to
+    // use repo-level tags (v1), component tags (foo/v1), or branch refs for
+    // nested actions. The extracted ref itself is the source of truth for the
+    // stable shape. A subsequent change from foo/v1 to v1 is caught because
+    // `compatibility` changes from Some("foo") to None.
+    if let Some(compatibility) = version_tag_compatibility(current_ref) {
+        return Ok(Some((
+            target_key,
+            ActionMeta {
+                package_name: package_name.to_string(),
+                ref_kind: "version-tag".to_string(),
+                compatibility,
+                ref_: None,
+            },
+        )));
+    }
+
+    Ok(Some((
+        target_key,
+        ActionMeta {
+            package_name: package_name.to_string(),
+            ref_kind: "branch".to_string(),
+            compatibility: None,
+            ref_: Some(current_ref.to_string()),
+        },
+    )))
+}
+
+fn is_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Returns the optional compatibility prefix for a semver-like action ref.
+/// For `v1.2.3` this is `None`; for `component/v1.2.3` or
+/// `component-v1.2.3` it is `Some("component")`.
+pub(crate) fn version_tag_compatibility(value: &str) -> Option<Option<String>> {
+    let value = value
+        .strip_prefix(|c| c == 'v' || c == 'V')
+        .unwrap_or(value);
+    if is_numeric_version(value) {
+        return Some(None);
+    }
+
+    // Tags with a namespace are separated from their semver suffix by a
+    // slash or hyphen. Try every separator so prerelease hyphens are not
+    // mistaken for the namespace delimiter.
+    for (separator, _) in value
+        .char_indices()
+        .filter(|(_, character)| *character == '/' || *character == '-')
+    {
+        let (prefix, suffix) = value.split_at(separator);
+        let suffix = suffix.get(1..).unwrap_or_default();
+        let suffix = suffix
+            .strip_prefix(|c| c == 'v' || c == 'V')
+            .unwrap_or(suffix);
+        if !prefix.is_empty() && is_numeric_version(suffix) {
+            return Some(Some(prefix.to_string()));
+        }
+    }
+    None
+}
+
+fn is_numeric_version(value: &str) -> bool {
+    let core_end = value.find(['-', '+']).unwrap_or(value.len());
+    let core = &value[..core_end];
+    let suffix = &value[core_end..];
+    let parts: Vec<_> = core.split('.').collect();
+    (1..=3).contains(&parts.len())
+        && !core.is_empty()
+        && (suffix.is_empty() || suffix.len() > 1)
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+pub(crate) fn canonical_manager_name(manager: &str) -> &str {
     match manager {
         "renovate-config-presets" => "renovate-config",
         _ => manager,

--- a/src/linters/renovate_deps/snapshot.rs
+++ b/src/linters/renovate_deps/snapshot.rs
@@ -285,6 +285,12 @@ fn action_meta_from_dep(dep: &serde_json::Value) -> anyhow::Result<Option<(Strin
         .and_then(|v| v.as_str())
         .or_else(|| {
             replace_string
+                .split_once('#')
+                .map(|(_, comment)| comment.trim())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            replace_string
                 .split('@')
                 .nth(1)
                 .and_then(|value| value.split_whitespace().next())
@@ -381,7 +387,7 @@ fn is_numeric_version(value: &str) -> bool {
             .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
-pub(crate) fn canonical_manager_name(manager: &str) -> &str {
+pub(super) fn canonical_manager_name(manager: &str) -> &str {
     match manager {
         "renovate-config-presets" => "renovate-config",
         _ => manager,

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -4,9 +4,9 @@ use super::rules::{
     ComparablePackageRule, ExtractVersionMismatch, RuleMatcher, equivalent_version_shapes,
     incomplete_meta_for_rules, relevant_dep_names, validate_extract_version_consistency,
 };
-use super::snapshot::{DepFiles, DepMeta};
+use super::snapshot::{ActionMeta, DepFiles, DepMeta, version_tag_compatibility};
 use super::*;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 type FileManagers<'a> = [(&'a str, &'a [(&'a str, &'a [&'a str])])];
 
@@ -15,6 +15,7 @@ fn log(config_json: &str) -> Vec<u8> {
 }
 
 fn log_current(config_json: &str) -> Vec<u8> {
+    let config_json = config_json.lines().map(str::trim).collect::<String>();
     format!(r#"{{"msg":"packageFiles with updates","config":{config_json}}}"#).into_bytes()
 }
 
@@ -53,6 +54,7 @@ fn snapshot(meta: &[(&str, Option<&str>, Option<&str>)], files: &FileManagers<'_
                 )
             })
             .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(files),
     }
 }
@@ -348,6 +350,156 @@ fn extracts_extended_dep_metadata_from_lookup_logs() {
 }
 
 #[test]
+fn extracts_action_metadata_per_monorepo_target() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","currentValue":"create-github-app-token/v0.2.2","replaceString":"grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2"},
+          {"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","currentValue":"main","replaceString":"grafana/shared-workflows/.github/workflows/sign-and-attest.yml@abc1234567890123456789012345678901234567 # main"}
+        ]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+
+    assert_eq!(result.action_meta.len(), 2);
+    assert_eq!(
+        result.action_meta["grafana/shared-workflows/actions/create-github-app-token"],
+        ActionMeta {
+            package_name: "grafana/shared-workflows".to_string(),
+            ref_kind: "version-tag".to_string(),
+            compatibility: Some("create-github-app-token".to_string()),
+            ref_: None,
+        }
+    );
+    assert_eq!(
+        result.action_meta["grafana/shared-workflows/.github/workflows/sign-and-attest.yml"]
+            .ref_
+            .as_deref(),
+        Some("main")
+    );
+}
+
+#[test]
+fn action_metadata_accepts_bare_version_for_nested_action() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"example/repo","packageName":"example/repo","depType":"action","currentValue":"v0.2.2","replaceString":"example/repo/actions/nested/action@ae92934a14a48b94494dbc06d74a81d47fe08a40 # v0.2.2"}
+        ]}]}"#,
+    );
+    assert!(
+        extract_deps(&log, &[]).unwrap().action_meta["example/repo/actions/nested/action"]
+            .compatibility
+            .is_none()
+    );
+}
+
+#[test]
+fn action_metadata_accepts_bare_version_for_top_level_action() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"actions/checkout","packageName":"actions/checkout","depType":"action","currentValue":"v4.2.2","replaceString":"actions/checkout@abc1234567890123456789012345678901234567 # v4.2.2"}
+        ]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+    let meta = &result.action_meta["actions/checkout"];
+    assert_eq!(meta.ref_kind, "version-tag");
+    assert!(meta.compatibility.is_none());
+}
+
+#[test]
+fn action_ref_classification_supports_major_and_prerelease_tags() {
+    assert_eq!(version_tag_compatibility("v4"), Some(None));
+    assert_eq!(
+        version_tag_compatibility("component/v1"),
+        Some(Some("component".into()))
+    );
+    assert_eq!(version_tag_compatibility("v1.2.3-rc.1+build.7"), Some(None));
+    assert_eq!(
+        version_tag_compatibility("component/v1.2.3-rc.1+build.7"),
+        Some(Some("component".into()))
+    );
+    assert_eq!(
+        version_tag_compatibility("component-v1.2.3-rc.1+build.7"),
+        Some(Some("component".into()))
+    );
+}
+
+#[test]
+fn action_metadata_accepts_branch_refs_for_nested_actions() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"example/repo","packageName":"example/repo","depType":"action","currentValue":"main","replaceString":"example/repo/actions/nested/action@abc1234567890123456789012345678901234567 # main"}
+        ]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+    let meta = &result.action_meta["example/repo/actions/nested/action"];
+    assert_eq!(meta.ref_kind, "branch");
+    assert_eq!(meta.ref_.as_deref(), Some("main"));
+}
+
+#[test]
+fn lookup_deterministic_digest_warning_is_invalid() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[{"depName":"grafana/shared-workflows","warnings":[{"message":"Could not determine new digest for update (github-digest package grafana/shared-workflows)"}]}]}]}"#,
+    );
+    let err = validate_lookup_action_warnings(&log, &[]).unwrap_err();
+    assert!(err.to_string().contains("invalid GitHub Action ref"));
+
+    assert!(
+        validate_lookup_action_warnings(b"Could not determine new digest for update\n", &[])
+            .is_ok()
+    );
+}
+
+#[test]
+fn lookup_no_result_warning_is_inconclusive() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[{"depName":"grafana/shared-workflows","warnings":[{"message":"Failed to look up github-tags package grafana/shared-workflows: no-result"}]}]}],"docker":[{"packageFile":"Dockerfile","deps":[{"depName":"grafana/shared-workflows","warnings":[{"message":"Could not determine new digest for update (docker package grafana/shared-workflows)"}]}]}]}"#,
+    );
+    assert!(validate_lookup_action_warnings(&log, &[]).is_ok());
+}
+
+#[test]
+fn lookup_action_warning_respects_manager_exclusion() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[{"depName":"grafana/shared-workflows","warnings":[{"message":"Could not determine new digest for update (github-digest package grafana/shared-workflows)"}]}]}]}"#,
+    );
+    let exclusions = vec!["github-actions".to_string()];
+    assert!(validate_lookup_action_warnings(&log, &exclusions).is_ok());
+}
+
+#[test]
+fn action_metadata_conflicts_are_rejected_for_same_target() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"example/repo","packageName":"example/repo","depType":"action","currentValue":"v1.2.3","replaceString":"example/repo/actions/nested/action@abc1234567890123456789012345678901234567 # v1.2.3"},
+          {"depName":"example/repo","packageName":"example/repo","depType":"action","currentValue":"main","replaceString":"example/repo/actions/nested/action@abc1234567890123456789012345678901234567 # main"}
+        ]}]}"#,
+    );
+    let err = extract_deps(&log, &[]).unwrap_err();
+    assert!(err.to_string().contains("conflicting stable metadata"));
+}
+
+#[test]
+fn action_metadata_respects_manager_exclusions() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","currentValue":"main","replaceString":"grafana/shared-workflows/.github/workflows/sign-and-attest.yml@abc1234567890123456789012345678901234567 # main"}
+        ]}]}"#,
+    );
+    let result = extract_deps(&log, &["github-actions".to_string()]).unwrap();
+    assert!(result.action_meta.is_empty());
+    assert!(result.files.is_empty());
+}
+
+#[test]
+fn reads_snapshot_without_action_metadata() {
+    let snapshot = read_snapshot(
+        r#"{"meta":{},"files":{"workflow.yml":{"github-actions":["actions/checkout"]}}}"#,
+    )
+    .unwrap();
+    assert!(snapshot.action_meta.is_empty());
+}
+
+#[test]
 fn extracts_legacy_manager_names_using_canonical_snapshot_keys() {
     let log = log(
         r#"{"renovate-config-presets":[{"packageFile":".github/renovate.json5","deps":[{"depName":"grafana/flint"}]}]}"#,
@@ -489,6 +641,7 @@ fn write_snapshot_serializes_canonical_dep_order() {
     let path = dir.path().join("out.json");
     let deps = Snapshot {
         meta: BTreeMap::new(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("package.json", &[("npm", &["zebra", "alpha", "moose"])])]),
     };
 
@@ -629,6 +782,7 @@ fn validate_extract_version_consistency_accepts_matching_extraction() {
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["actionlint"])])]),
     };
 
@@ -650,6 +804,7 @@ fn validate_extract_version_consistency_accepts_normalized_current_version() {
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["actionlint"])])]),
     };
 
@@ -671,6 +826,7 @@ fn validate_extract_version_consistency_accepts_normalized_prefixed_current_valu
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["shellcheck"])])]),
     };
 
@@ -692,6 +848,7 @@ fn validate_extract_version_consistency_flags_mismatch() {
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["biome"])])]),
     };
 
@@ -719,6 +876,7 @@ fn validate_extract_version_consistency_flags_no_match() {
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["biome"])])]),
     };
 
@@ -755,6 +913,7 @@ fn patch_semver_equivalent_mise_values_rewrites_to_preferred_shape() {
         )]
         .into_iter()
         .collect(),
+        action_meta: BTreeMap::new(),
         files: dep_files(&[("mise.toml", &[("mise", &["protoc"])])]),
     };
     let mismatches = extract_version_mismatches(&snap).unwrap();

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -392,6 +392,22 @@ fn action_metadata_accepts_bare_version_for_nested_action() {
 }
 
 #[test]
+fn action_metadata_uses_ref_comment_without_current_value() {
+    let log = log_current(
+        r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[
+          {"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","replaceString":"grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2"}
+        ]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+    let meta = &result.action_meta["grafana/shared-workflows/actions/create-github-app-token"];
+    assert_eq!(meta.ref_kind, "version-tag");
+    assert_eq!(
+        meta.compatibility.as_deref(),
+        Some("create-github-app-token")
+    );
+}
+
+#[test]
 fn action_metadata_accepts_bare_version_for_top_level_action() {
     let log = log_current(
         r#"{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[

--- a/tests/cases/renovate-deps/action-metadata-populated/files/.github/renovate.json5
+++ b/tests/cases/renovate-deps/action-metadata-populated/files/.github/renovate.json5
@@ -1,0 +1,3 @@
+{
+  extends: ["config:recommended"]
+}

--- a/tests/cases/renovate-deps/action-metadata-populated/files/.github/workflows/ci.yml
+++ b/tests/cases/renovate-deps/action-metadata-populated/files/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  sign:
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@0123456789012345678901234567890123456789 # main
+    steps:
+      - uses: grafana/shared-workflows/actions/create-github-app-token@0123456789012345678901234567890123456789 # create-github-app-token/v0.2.2

--- a/tests/cases/renovate-deps/action-metadata-populated/files/mise.toml
+++ b/tests/cases/renovate-deps/action-metadata-populated/files/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"npm:renovate" = "43.150.0"

--- a/tests/cases/renovate-deps/action-metadata-populated/test.toml
+++ b/tests/cases/renovate-deps/action-metadata-populated/test.toml
@@ -1,0 +1,43 @@
+[expected]
+args = "run --full --fix renovate-deps"
+exit = 1
+stderr = '''
+flint: fixed: renovate-deps — commit before pushing
+'''
+
+[env]
+GITHUB_TOKEN = "token"
+
+[expected.files]
+".github/renovate-tracked-deps.json" = '''
+{
+  "meta": {},
+  "files": {
+    ".github/workflows/ci.yml": {
+      "github-actions": [
+        "grafana/shared-workflows"
+      ]
+    }
+  },
+  "actionMeta": {
+    "grafana/shared-workflows/.github/workflows/sign-and-attest.yml": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "branch",
+      "ref": "main"
+    },
+    "grafana/shared-workflows/actions/create-github-app-token": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "create-github-app-token"
+    }
+  }
+}
+'''
+
+[fake_bins]
+renovate = '''
+#!/bin/sh
+set -eu
+
+printf '%s\n' '{"msg":"Extracted dependencies","packageFiles":{"github-actions":[{"packageFile":".github/workflows/ci.yml","deps":[{"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","currentValue":"main","replaceString":"grafana/shared-workflows/.github/workflows/sign-and-attest.yml@0123456789012345678901234567890123456789 # main"},{"depName":"grafana/shared-workflows","packageName":"grafana/shared-workflows","depType":"action","currentValue":"create-github-app-token/v0.2.2","replaceString":"grafana/shared-workflows/actions/create-github-app-token@0123456789012345678901234567890123456789 # create-github-app-token/v0.2.2"}]}]}}'
+'''

--- a/tests/cases/renovate-deps/extract-version-autofix/test.toml
+++ b/tests/cases/renovate-deps/extract-version-autofix/test.toml
@@ -37,7 +37,8 @@ GITHUB_TOKEN = "token"
         "biome"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 '''
 

--- a/tests/cases/renovate-deps/extract-version-semver-equivalent-no-autofix/test.toml
+++ b/tests/cases/renovate-deps/extract-version-semver-equivalent-no-autofix/test.toml
@@ -28,7 +28,8 @@ protoc = "35"
         "protoc"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 '''
 

--- a/tests/cases/renovate-deps/fix-create/test.toml
+++ b/tests/cases/renovate-deps/fix-create/test.toml
@@ -24,6 +24,7 @@ GITHUB_TOKEN = "token"
         "lodash"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 """

--- a/tests/cases/renovate-deps/fix-update/test.toml
+++ b/tests/cases/renovate-deps/fix-update/test.toml
@@ -24,6 +24,7 @@ GITHUB_TOKEN = "token"
         "lodash"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 """

--- a/tests/cases/renovate-deps/full-slow-lookup-when-rule-needs-meta/test.toml
+++ b/tests/cases/renovate-deps/full-slow-lookup-when-rule-needs-meta/test.toml
@@ -24,7 +24,8 @@ GITHUB_TOKEN = "token"
         "actionlint"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 """
 

--- a/tests/cases/renovate-deps/metadata-stale-fix-refreshes/test.toml
+++ b/tests/cases/renovate-deps/metadata-stale-fix-refreshes/test.toml
@@ -34,7 +34,8 @@ lookup
         "Swatinem/rust-cache"
       ]
     }
-  }
+  },
+  "actionMeta": {}
 }
 """
 


### PR DESCRIPTION
## What changed

- Add an additive `actionMeta` section to Renovate dependency snapshots.
- Track complete GitHub Action targets with generic ref-shape metadata for top-level and nested actions.
- Validate deterministic GitHub Actions digest warnings during lookup while treating no-result, authentication, network, and excluded-manager cases as inconclusive.
- Add coverage for legacy snapshots, manager exclusions, namespace changes, branch refs, major-only/prerelease/build tags, conflicts, and warning filtering.
- Document the stable snapshot metadata model.

## Root cause

Renovate uses the same package name for every path in a monorepo such as `grafana/shared-workflows`. A package-only metadata entry cannot distinguish component-tag namespaces from branch-pinned reusable workflows. The missing component prefix in `v0.2.2` therefore was not represented in the existing snapshot.

## Design

`actionMeta` is keyed by the complete `package/path` target. Semver-like refs store an optional compatibility prefix; non-semver refs store the stable branch/ref. Routine version bumps within a namespace do not churn the snapshot. Lookup-only validation inspects resolved `github-actions` dependency warnings and fails only deterministic `Could not determine new digest for update` warnings.

## Validation

- `cargo test renovate_deps` — 93 passed
- `mise run lint:fix` — passed
- `mise run lint` — passed
- Full `cargo test` — 318 passed; one unrelated environment failure because `dotenv-linter`, `checkstyle`, and `ktlint` were unavailable on PATH.

Related to grafana/shared-workflows#2255
