### PR TITLE
feat(cli): add changed-files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <p align="center">
   <a href="docs/cli.md">CLI reference</a> ·
+  <a href="docs/changed-files.md">Changed-file discovery</a> ·
   <a href="docs/check-model.md">How checks work</a> ·
   <a href="docs/linters.md">Linters</a> ·
   <a href="docs/why.md">Why flint?</a> ·
@@ -129,6 +130,9 @@ every matching tracked file. Flint also skips files marked
 so GitHub and other tools can reuse the same metadata.
 
 For more commands and flags, see the [CLI reference](docs/cli.md).
+To reuse Flint's Git-aware file selection from another formatter or repository
+task, see [changed-file discovery](docs/changed-files.md) and run
+`flint changed-files`.
 
 > [!NOTE]
 > In rare cases (currently only `renovate-deps`) a failure may show up

--- a/docs/changed-files.md
+++ b/docs/changed-files.md
@@ -46,6 +46,11 @@ Flint currently represents Git paths as UTF-8 strings. A path containing
 invalid UTF-8 bytes is lossily converted; `--null` makes separators safe for
 whitespace and newlines, but does not preserve arbitrary non-UTF-8 bytes.
 
+Flint computes the complete deterministic set before emitting it, then writes
+the output incrementally. For large or unusual path sets, consume `--null`
+directly as a stream rather than using shell command substitution. Pagination
+is intentionally not provided: the command emits one complete snapshot.
+
 ## Filtering
 
 Use `--include GLOB` and `--exclude GLOB` to select a subset of Flint's
@@ -89,6 +94,13 @@ if files:
     raise SystemExit(subprocess.run(["some-formatter", *files]).returncode)
 '
 ```
+
+On Unix, `xargs -0` can batch paths for tools that accept file arguments, but
+its batching options and availability vary across platforms. Cross-platform
+callers should parse the NUL stream incrementally and choose their own
+argument-size limit. If a caller only needs to know whether any matching path
+exists, it can stop after the first relevant record instead of collecting the
+whole list.
 
 Use a NUL-aware reader in other languages, for example Python:
 

--- a/docs/changed-files.md
+++ b/docs/changed-files.md
@@ -1,0 +1,91 @@
+# Changed-file discovery
+
+`flint changed-files` exposes Flint's Git-aware file selection for repository
+tasks that need to orchestrate tools other than Flint's built-in checks. It is
+also useful for hooks and editor integrations that should select exactly the
+same files as `flint run`.
+
+```bash
+flint changed-files
+```
+
+## Semantics
+
+Without `--full`, Flint selects the union of:
+
+- committed changes in the three-dot range from the merge base with the
+  configured base branch to `HEAD`;
+- unstaged worktree changes; and
+- staged index changes.
+
+Untracked files are not included until they are staged. `--full` lists tracked
+files only.
+
+`--new-from-rev REV` replaces the configured base branch when resolving the
+merge base. `--to-ref REF` replaces `HEAD` as the end of the committed range.
+These options have the same meaning as their `flint run` counterparts. If a
+merge base cannot be resolved, Flint falls back to full tracked-file
+selection, as it does for a lint run.
+
+The revision options also accept `FLINT_NEW_FROM_REV` and `FLINT_TO_REF`, which
+is useful when a shared task forwards the same revision context to both
+`flint run` and `flint changed-files`. Explicit command-line options take
+precedence over environment variables.
+
+`--full` explicitly selects all tracked files. In either mode, Flint excludes
+paths that:
+
+- do not exist in the worktree, including deleted files;
+- are marked `linguist-generated` in `.gitattributes`;
+- are built-in Flint-managed paths; or
+- match `settings.exclude` in `flint.toml`.
+
+The remaining paths are repository-relative, sorted deterministically, and
+printed without diagnostic output on stdout. Errors are reported on stderr.
+Flint currently represents Git paths as UTF-8 strings. A path containing
+invalid UTF-8 bytes is lossily converted; `--null` makes separators safe for
+whitespace and newlines, but does not preserve arbitrary non-UTF-8 bytes.
+
+## Output formats
+
+The default output has one path per line:
+
+```text
+src/main.rs
+src/runner.rs
+```
+
+For scripts, use `--null`. It terminates every path with a NUL byte, so spaces,
+tabs, quotes, and newlines in a filename cannot be mistaken for separators:
+
+```bash
+flint changed-files --null | python -c '
+import subprocess, sys
+raw = sys.stdin.buffer.read().rstrip(b"\0")
+files = raw.split(b"\0") if raw else []
+if files:
+    raise SystemExit(subprocess.run(["some-formatter", *files]).returncode)
+'
+```
+
+Use a NUL-aware reader in other languages, for example Python:
+
+```python
+import subprocess
+
+paths = subprocess.check_output(["flint", "changed-files", "--null"])
+payload = paths.rstrip(b"\0")
+files = payload.split(b"\0") if payload else []
+```
+
+## Tool-specific filtering
+
+Flint deliberately does not provide formatter-specific flags. Callers should
+filter this generic list according to their own ownership rules—for example,
+selecting only Scala and Groovy files before invoking Spotless. Keeping that
+policy outside Flint allows the same command to serve different repositories,
+formatters, hooks, and orchestration tasks while preserving one canonical
+definition of changed files.
+
+See the [CLI reference](cli.md#flint-changed-files) for the complete command
+overview.

--- a/docs/changed-files.md
+++ b/docs/changed-files.md
@@ -18,8 +18,8 @@ Without `--full`, Flint selects the union of:
 - unstaged worktree changes; and
 - staged index changes.
 
-Untracked files are not included until they are staged. `--full` lists tracked
-files only.
+Untracked files are not included until they are staged. `--full` selects all
+eligible tracked files; it does not include untracked files.
 
 `--new-from-rev REV` replaces the configured base branch when resolving the
 merge base. `--to-ref REF` replaces `HEAD` as the end of the committed range.
@@ -27,13 +27,13 @@ These options have the same meaning as their `flint run` counterparts. If a
 merge base cannot be resolved, Flint falls back to full tracked-file
 selection, as it does for a lint run.
 
-The revision options also accept `FLINT_NEW_FROM_REV` and `FLINT_TO_REF`, which
-is useful when a shared task forwards the same revision context to both
-`flint run` and `flint changed-files`. Explicit command-line options take
-precedence over environment variables.
+The revision options also accept values from the `FLINT_NEW_FROM_REV` and
+`FLINT_TO_REF` environment variables. This is useful when a shared task
+forwards the same revision context to both `flint run` and `flint changed-files`.
+An explicitly supplied command-line option takes precedence over its
+environment variable.
 
-`--full` explicitly selects all tracked files. In either mode, Flint excludes
-paths that:
+In either mode, Flint first excludes paths that:
 
 - do not exist in the worktree, including deleted files;
 - are marked `linguist-generated` in `.gitattributes`;
@@ -45,6 +45,28 @@ printed without diagnostic output on stdout. Errors are reported on stderr.
 Flint currently represents Git paths as UTF-8 strings. A path containing
 invalid UTF-8 bytes is lossily converted; `--null` makes separators safe for
 whitespace and newlines, but does not preserve arbitrary non-UTF-8 bytes.
+
+## Filtering
+
+Use `--include GLOB` and `--exclude GLOB` to select a subset of Flint's
+already-eligible paths. Each option may be repeated. Includes are combined with
+OR; exclusions are applied afterward and always win. With no includes, all
+eligible paths are candidates. An include cannot re-include a generated,
+built-in, configured-excluded, deleted, or untracked path.
+
+Patterns match either a repository-relative path or its basename, so `*.scala`
+matches Scala files in any directory while `src/**/*.scala` restricts the
+selection to `src`. For example, a formatter task can select Scala and Groovy
+files while retaining Flint's change semantics:
+
+```bash
+flint changed-files --null \
+  --include '*.scala' --include '*.groovy' \
+  --exclude 'src/generated/**'
+```
+
+Filtering is generic rather than formatter-specific. A caller still decides
+which patterns belong to Spotless, Flint, or another tool.
 
 ## Output formats
 
@@ -77,15 +99,6 @@ paths = subprocess.check_output(["flint", "changed-files", "--null"])
 payload = paths.rstrip(b"\0")
 files = payload.split(b"\0") if payload else []
 ```
-
-## Tool-specific filtering
-
-Flint deliberately does not provide formatter-specific flags. Callers should
-filter this generic list according to their own ownership rules—for example,
-selecting only Scala and Groovy files before invoking Spotless. Keeping that
-policy outside Flint allows the same command to serve different repositories,
-formatters, hooks, and orchestration tasks while preserving one canonical
-definition of changed files.
 
 See the [CLI reference](cli.md#flint-changed-files) for the complete command
 overview.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,9 +61,7 @@ See the dedicated [changed-file discovery guide](changed-files.md) for exact
 selection semantics and integration examples.
 
 Paths are separated by newlines by default. Use `--null` for machine-readable
-output when paths may contain whitespace or newlines:
-
-See the [NUL-aware examples](changed-files.md#output-formats), including an
+output when paths may contain whitespace or newlines. See the [NUL-aware examples](changed-files.md#output-formats), including an
 empty-output-safe Python invocation. Flint currently represents Git paths as
 UTF-8 strings, so `--null` does not preserve arbitrary non-UTF-8 bytes.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,13 +46,15 @@ Deleted files, generated files marked with
 `flint.toml` are omitted. Output is deterministic and contains only existing
 eligible files.
 
-Use `--full` to list every eligible tracked file. `--new-from-rev REV` and
-`--to-ref REF` provide the same revision controls as `flint run`:
+Use `--full` to select every eligible tracked file; untracked files remain
+excluded. `--new-from-rev REV` and `--to-ref REF` provide the same revision
+controls as `flint run`:
 
 ```bash
 flint changed-files
 flint changed-files --full
 flint changed-files --new-from-rev origin/main --to-ref HEAD
+flint changed-files --include '*.scala' --include '*.groovy' --exclude 'src/generated/**'
 ```
 
 See the dedicated [changed-file discovery guide](changed-files.md) for exact
@@ -65,10 +67,13 @@ See the [NUL-aware examples](changed-files.md#output-formats), including an
 empty-output-safe Python invocation. Flint currently represents Git paths as
 UTF-8 strings, so `--null` does not preserve arbitrary non-UTF-8 bytes.
 
-The command is intentionally generic: callers can filter the returned paths
-for the files owned by a particular formatter or other tool. This lets a
-repository's orchestration task and hooks share Flint's file-discovery
-semantics without putting tool-specific policy in Flint.
+`--include GLOB` and `--exclude GLOB` may be repeated to filter the eligible
+paths. Includes are ORed, exclusions are applied afterward and take precedence,
+and patterns match either repository-relative paths or basenames (so
+`*.scala` matches Scala files anywhere). Invalid patterns are reported as
+command errors. The options are generic rather than formatter-specific, so a
+repository can use the same command for Spotless, Flint, or another tool while
+keeping ownership policy in its orchestration task.
 
 ## `flint run` flags
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,7 @@
 
 ```text
 flint run [OPTIONS] [LINTERS...]
+flint changed-files [OPTIONS]
 flint init [OPTIONS]
 flint hook install
 flint linters
@@ -33,6 +34,41 @@ echo $1
 ...
 flint: fixed: cargo-fmt — commit before pushing | review: shellcheck
 ```
+
+## `flint changed-files`
+
+`flint changed-files` prints the repository-relative files selected by Flint's
+Git-aware file discovery, without running any linters. It uses the same
+changed-file semantics as `flint run`: committed changes since the merge base,
+plus staged and unstaged changes. Untracked files are excluded until staged.
+Deleted files, generated files marked with
+`linguist-generated`, Flint-managed files, and paths excluded by
+`flint.toml` are omitted. Output is deterministic and contains only existing
+eligible files.
+
+Use `--full` to list every eligible tracked file. `--new-from-rev REV` and
+`--to-ref REF` provide the same revision controls as `flint run`:
+
+```bash
+flint changed-files
+flint changed-files --full
+flint changed-files --new-from-rev origin/main --to-ref HEAD
+```
+
+See the dedicated [changed-file discovery guide](changed-files.md) for exact
+selection semantics and integration examples.
+
+Paths are separated by newlines by default. Use `--null` for machine-readable
+output when paths may contain whitespace or newlines:
+
+See the [NUL-aware examples](changed-files.md#output-formats), including an
+empty-output-safe Python invocation. Flint currently represents Git paths as
+UTF-8 strings, so `--null` does not preserve arbitrary non-UTF-8 bytes.
+
+The command is intentionally generic: callers can filter the returned paths
+for the files owned by a particular formatter or other tool. This lets a
+repository's orchestration task and hooks share Flint's file-discovery
+semantics without putting tool-specific policy in Flint.
 
 ## `flint run` flags
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -133,7 +133,7 @@ pub fn all(project_root: &Path, cfg: &Config) -> Result<FileList> {
 
 fn all_files(project_root: &Path, exclude: &GlobSet) -> Result<FileList> {
     let out = Command::new("git")
-        .args(["ls-files"])
+        .args(["ls-files", "-z"])
         .current_dir(project_root)
         .output()
         .context("git ls-files")?;
@@ -143,10 +143,7 @@ fn all_files(project_root: &Path, exclude: &GlobSet) -> Result<FileList> {
         anyhow::bail!("git ls-files failed ({}): {}", out.status, stderr.trim());
     }
 
-    let names: BTreeSet<String> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(str::to_string)
-        .collect();
+    let names = parse_nul_names(&out.stdout);
 
     Ok(FileList {
         files: filter_names(project_root, exclude, names)?,
@@ -157,7 +154,7 @@ fn all_files(project_root: &Path, exclude: &GlobSet) -> Result<FileList> {
 }
 
 fn git_diff_names(project_root: &Path, extra_args: &[&str]) -> Result<Vec<String>> {
-    let mut args = vec!["diff", "--name-only"];
+    let mut args = vec!["diff", "--name-only", "-z"];
     args.extend_from_slice(extra_args);
     let out = Command::new("git")
         .args(&args)
@@ -174,10 +171,16 @@ fn git_diff_names(project_root: &Path, extra_args: &[&str]) -> Result<Vec<String
         );
     }
 
-    Ok(String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(str::to_string)
-        .collect())
+    Ok(parse_nul_names(&out.stdout).into_iter().collect())
+}
+
+fn parse_nul_names(bytes: &[u8]) -> BTreeSet<String> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+        .map(String::from_utf8_lossy)
+        .map(std::borrow::Cow::into_owned)
+        .collect()
 }
 
 fn filter_names(

--- a/src/files.rs
+++ b/src/files.rs
@@ -131,6 +131,62 @@ pub fn all(project_root: &Path, cfg: &Config) -> Result<FileList> {
     all_files(project_root, &exclude)
 }
 
+/// Apply caller-owned path filters to an already eligible file list.
+///
+/// Flint owns discovery and its built-in/configured exclusions. These filters
+/// are deliberately applied afterward so an include cannot re-include a path
+/// that discovery excluded (for example a generated file). An include matches
+/// either the repository-relative path or its basename, like check patterns.
+pub fn apply_filters(
+    project_root: &Path,
+    mut file_list: FileList,
+    includes: &[String],
+    excludes: &[String],
+) -> Result<FileList> {
+    let include_set = build_cli_glob_set(includes, "--include")?;
+    let exclude_set = build_cli_glob_set(excludes, "--exclude")?;
+
+    file_list.files.retain(|path| {
+        let (relative, basename) = relative_and_basename(project_root, path);
+        let included = includes.is_empty()
+            || include_set.is_match(&relative)
+            || include_set.is_match(&basename);
+        let excluded = exclude_set.is_match(&relative) || exclude_set.is_match(&basename);
+        included && !excluded
+    });
+
+    Ok(file_list)
+}
+
+fn build_cli_glob_set(patterns: &[String], option: &str) -> Result<GlobSet> {
+    let patterns: Vec<&str> = patterns.iter().map(String::as_str).collect();
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let glob = GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .build()
+            .map_err(|error| {
+                anyhow::anyhow!("invalid {option} glob pattern {pattern:?}: {error}")
+            })?;
+        builder.add(glob);
+    }
+    builder
+        .build()
+        .map_err(|error| anyhow::anyhow!("invalid {option} glob patterns: {error}"))
+}
+
+fn relative_and_basename(project_root: &Path, path: &Path) -> (String, String) {
+    let relative = path.strip_prefix(project_root).unwrap_or(path);
+    let relative = relative
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/");
+    let basename = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    (relative, basename)
+}
+
 fn all_files(project_root: &Path, exclude: &GlobSet) -> Result<FileList> {
     let out = Command::new("git")
         .args(["ls-files", "-z"])
@@ -271,16 +327,10 @@ pub fn match_files<'a>(
     files
         .iter()
         .filter(|p| {
-            let rel = p.strip_prefix(project_root).unwrap_or(p);
-            let rel_str = rel.to_string_lossy();
-            let file_name = p
-                .file_name()
-                .map(|n| n.to_string_lossy())
-                .unwrap_or_default();
-            let included =
-                patterns.is_match(file_name.as_ref()) || patterns.is_match(rel_str.as_ref());
-            let excluded = exclude_patterns.is_match(file_name.as_ref())
-                || exclude_patterns.is_match(rel_str.as_ref());
+            let (rel_str, file_name) = relative_and_basename(project_root, p);
+            let included = patterns.is_match(&file_name) || patterns.is_match(&rel_str);
+            let excluded =
+                exclude_patterns.is_match(&file_name) || exclude_patterns.is_match(&rel_str);
             included && !excluded
         })
         .collect()
@@ -397,6 +447,46 @@ mod tests {
         let matched = match_files(&files, &["*.java"], &["src/excluded/**"], tmp.path());
 
         assert_eq!(matched, vec![&files[0]]);
+    }
+
+    #[test]
+    fn apply_filters_matches_basenames_and_paths_and_excludes_win() {
+        let root = Path::new("/repo");
+        let list = FileList {
+            files: vec![
+                root.join("src/Foo.scala"),
+                root.join("src/Foo.groovy"),
+                root.join("test/Foo.scala"),
+                root.join("README.md"),
+            ],
+            changed_paths: vec![],
+            merge_base: None,
+            full: true,
+        };
+
+        let filtered = apply_filters(
+            root,
+            list,
+            &["*.scala".to_string(), "README.md".to_string()],
+            &["test/**".to_string(), "README.md".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(filtered.files, vec![root.join("src/Foo.scala")]);
+    }
+
+    #[test]
+    fn apply_filters_rejects_invalid_cli_globs() {
+        let root = Path::new("/repo");
+        let list = FileList {
+            files: vec![root.join("file.txt")],
+            changed_paths: vec![],
+            merge_base: None,
+            full: true,
+        };
+
+        let error = apply_filters(root, list, &["[".to_string()], &[]).unwrap_err();
+        assert!(error.to_string().contains("invalid --include glob pattern"));
     }
 
     /// Regression test for os error 206 (ERROR_FILENAME_EXCED_RANGE) on Windows: the previous

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,12 @@ mod registry;
 mod runner;
 mod setup;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 use registry::{CheckKind, FixBehavior, LinterConfig, Scope};
 use runner::{CheckResult, RunContext as RunnerRunContext, RunOptions};
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
@@ -30,6 +31,8 @@ struct Cli {
 enum SubCommand {
     /// Lint the code.
     Run(RunArgs),
+    /// Print the repository files selected by Flint's changed-file discovery.
+    ChangedFiles(ChangedFilesArgs),
     /// List available linters and their status.
     Linters(LintersArgs),
     /// Set up linters in mise.toml for this project.
@@ -121,6 +124,26 @@ struct RunArgs {
     linters: Vec<String>,
 }
 
+#[derive(Args, Debug)]
+struct ChangedFilesArgs {
+    /// Print all eligible tracked files instead of only changed files.
+    #[arg(long)]
+    full: bool,
+
+    /// Select changes after git revision REV (default: merge base with base branch).
+    #[arg(long, value_name = "REV", env = "FLINT_NEW_FROM_REV")]
+    new_from_rev: Option<String>,
+
+    /// Compare changed files to this ref (default: HEAD).
+    #[arg(long, value_name = "REF", env = "FLINT_TO_REF")]
+    to_ref: Option<String>,
+
+    /// Separate paths with NUL bytes instead of newlines.
+    /// Use this when paths may contain whitespace or newlines.
+    #[arg(long)]
+    null: bool,
+}
+
 impl From<&RunArgs> for FixSummaryOptions {
     fn from(args: &RunArgs) -> Self {
         Self {
@@ -171,6 +194,17 @@ async fn main() -> Result<()> {
                 print_linters(&registry, &mise_tools, &cfg);
             }
         }
+        SubCommand::ChangedFiles(args) => {
+            let cfg = config::load(&config_dir)?;
+            let file_list = files::changed(
+                &project_root,
+                &cfg,
+                args.full,
+                args.new_from_rev.as_deref(),
+                args.to_ref.as_deref(),
+            )?;
+            print_changed_files(&project_root, &file_list.files, args.null)?;
+        }
         SubCommand::Init(args) => {
             if args.only.is_empty() {
                 init::run(
@@ -198,6 +232,46 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_changed_files(project_root: &Path, files: &[PathBuf], nul: bool) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    write_changed_files(&mut stdout, project_root, files, nul)
+}
+
+fn write_changed_files<W: Write>(
+    stdout: &mut W,
+    project_root: &Path,
+    files: &[PathBuf],
+    nul: bool,
+) -> Result<()> {
+    let separator = if nul { "\0" } else { "\n" };
+    for path in files {
+        let relative = path
+            .strip_prefix(project_root)
+            .with_context(|| format!("file is outside project root: {}", path.display()))?;
+        let relative = relative
+            .to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/");
+        if let Err(error) = stdout.write_all(relative.as_bytes()) {
+            if error.kind() == std::io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(error.into());
+        }
+        if let Err(error) = stdout.write_all(separator.as_bytes()) {
+            if error.kind() == std::io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(error.into());
+        }
+    }
+    match stdout.flush() {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 async fn run(
@@ -1279,9 +1353,11 @@ fn display_binary(check: &registry::Check) -> &'static str {
 mod tests {
     use super::{
         RunArgs, display_binary, linter_status, render_linters_table, unsupported_config,
-        use_filtered_run_policy,
+        use_filtered_run_policy, write_changed_files,
     };
     use crate::{config, registry};
+    use std::io;
+    use std::io::Write;
     use std::path::Path;
 
     fn run_args() -> RunArgs {
@@ -1296,6 +1372,26 @@ mod tests {
             time: false,
             linters: Vec::new(),
         }
+    }
+
+    #[test]
+    fn changed_files_treats_broken_pipe_as_success() {
+        struct ClosedPipe;
+
+        impl Write for ClosedPipe {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let root = Path::new("/tmp/project");
+        let files = [root.join("file.txt")];
+        let mut stdout = ClosedPipe;
+        assert!(write_changed_files(&mut stdout, root, &files, false).is_ok());
     }
 
     fn mise_tools_from(content: &str) -> std::collections::HashMap<String, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,9 +126,17 @@ struct RunArgs {
 
 #[derive(Args, Debug)]
 struct ChangedFilesArgs {
-    /// Print all eligible tracked files instead of only changed files.
+    /// Select all eligible tracked files instead of only changed files.
     #[arg(long)]
     full: bool,
+
+    /// Include paths matching GLOB. May be repeated; patterns are combined with OR.
+    #[arg(long, value_name = "GLOB", action = clap::ArgAction::Append)]
+    include: Vec<String>,
+
+    /// Exclude paths matching GLOB. May be repeated; exclusions take precedence over includes.
+    #[arg(long, value_name = "GLOB", action = clap::ArgAction::Append)]
+    exclude: Vec<String>,
 
     /// Select changes after git revision REV (default: merge base with base branch).
     #[arg(long, value_name = "REV", env = "FLINT_NEW_FROM_REV")]
@@ -203,6 +211,8 @@ async fn main() -> Result<()> {
                 args.new_from_rev.as_deref(),
                 args.to_ref.as_deref(),
             )?;
+            let file_list =
+                files::apply_filters(&project_root, file_list, &args.include, &args.exclude)?;
             print_changed_files(&project_root, &file_list.files, args.null)?;
         }
         SubCommand::Init(args) => {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -60,6 +60,203 @@ fn git_repo() -> TempDir {
     dir
 }
 
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to spawn git");
+    assert!(
+        out.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_stdout(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to spawn git");
+    assert!(
+        out.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("git output should be UTF-8")
+}
+
+#[test]
+fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
+    let repo = git_repo();
+    let root = repo.path();
+
+    std::fs::create_dir_all(root.join("excluded")).unwrap();
+    std::fs::write(
+        root.join(".gitattributes"),
+        "generated.txt linguist-generated\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("flint.toml"),
+        "[settings]\nexclude = [\"excluded/**\"]\n",
+    )
+    .unwrap();
+    for name in [
+        "staged.txt",
+        "unstaged.txt",
+        "deleted.txt",
+        "generated.txt",
+        "excluded/ignored.txt",
+    ] {
+        std::fs::write(root.join(name), "base\n").unwrap();
+    }
+    git(root, &["add", "--all"]);
+    git(root, &["commit", "-q", "-m", "base"]);
+    git(root, &["switch", "-q", "-c", "feature"]);
+
+    std::fs::write(root.join("committed.txt"), "committed\n").unwrap();
+    std::fs::write(root.join("line\nbreak.txt"), "newline\n").unwrap();
+    std::fs::write(root.join("space name.txt"), "space\n").unwrap();
+    git(
+        root,
+        &[
+            "add",
+            "--",
+            "committed.txt",
+            "line\nbreak.txt",
+            "space name.txt",
+        ],
+    );
+    git(root, &["commit", "-q", "-m", "committed changes"]);
+
+    std::fs::write(root.join("staged.txt"), "staged\n").unwrap();
+    git(root, &["add", "--", "staged.txt"]);
+    std::fs::write(root.join("unstaged.txt"), "unstaged\n").unwrap();
+    git(root, &["rm", "-q", "--", "deleted.txt"]);
+    std::fs::write(root.join("generated.txt"), "generated changed\n").unwrap();
+    std::fs::write(root.join("excluded/ignored.txt"), "excluded changed\n").unwrap();
+    std::fs::write(root.join("untracked.txt"), "not staged\n").unwrap();
+
+    let out = flint_with_env(&["changed-files", "--null"], root, &[]);
+    assert!(out.status.success(), "{:?}", combined_output(&out));
+    assert!(out.stderr.is_empty(), "unexpected stderr: {:?}", out.stderr);
+
+    let mut expected = [
+        "committed.txt",
+        "line\nbreak.txt",
+        "space name.txt",
+        "staged.txt",
+        "unstaged.txt",
+    ];
+    expected.sort_unstable();
+    let expected = expected.join("\0") + "\0";
+    assert_eq!(out.stdout, expected.as_bytes());
+
+    let line_output = flint_with_env(&["changed-files"], root, &[]);
+    assert!(
+        line_output.status.success(),
+        "{:?}",
+        combined_output(&line_output)
+    );
+    let mut expected_lines = [
+        "committed.txt",
+        "line\nbreak.txt",
+        "space name.txt",
+        "staged.txt",
+        "unstaged.txt",
+    ];
+    expected_lines.sort_unstable();
+    let expected_lines = expected_lines.join("\n") + "\n";
+    assert_eq!(line_output.stdout, expected_lines.as_bytes());
+
+    let base = git_stdout(root, &["rev-parse", "main"]);
+    let args = ["changed-files", "--null", "--new-from-rev", base.trim()];
+    let from_rev = flint_with_env(&args, root, &[]);
+    assert!(
+        from_rev.status.success(),
+        "{:?}",
+        combined_output(&from_rev)
+    );
+    assert_eq!(from_rev.stdout, out.stdout);
+
+    let env_options = flint_with_env(
+        &["changed-files", "--null"],
+        root,
+        &[
+            ("FLINT_NEW_FROM_REV", base.trim()),
+            ("FLINT_TO_REF", "HEAD"),
+        ],
+    );
+    assert!(
+        env_options.status.success(),
+        "{:?}",
+        combined_output(&env_options)
+    );
+    assert_eq!(env_options.stdout, out.stdout);
+
+    let to_main = flint_with_env(&["changed-files", "--null", "--to-ref", "main"], root, &[]);
+    assert!(to_main.status.success(), "{:?}", combined_output(&to_main));
+    assert_eq!(to_main.stdout, b"staged.txt\0unstaged.txt\0");
+
+    let full = flint_with_env(&["changed-files", "--full", "--null"], root, &[]);
+    assert!(full.status.success(), "{:?}", combined_output(&full));
+    let full_again = flint_with_env(&["changed-files", "--full", "--null"], root, &[]);
+    assert_eq!(full.stdout, full_again.stdout);
+    let fallback = flint_with_env(
+        &["changed-files", "--null", "--new-from-rev", "missing-ref"],
+        root,
+        &[],
+    );
+    assert!(
+        fallback.status.success(),
+        "{:?}",
+        combined_output(&fallback)
+    );
+    assert_eq!(fallback.stdout, full.stdout);
+    let full_paths = full
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    assert!(full_paths.windows(2).all(|pair| pair[0] < pair[1]));
+    assert!(full_paths.iter().any(|path| *path == b"committed.txt"));
+    assert!(full_paths.iter().any(|path| *path == b"line\nbreak.txt"));
+    assert!(full_paths.iter().any(|path| *path == b"space name.txt"));
+    assert!(!full_paths.iter().any(|path| *path == b"generated.txt"));
+    assert!(
+        !full_paths
+            .iter()
+            .any(|path| *path == b"excluded/ignored.txt")
+    );
+    assert!(!full_paths.iter().any(|path| *path == b"deleted.txt"));
+    assert!(!full_paths.iter().any(|path| *path == b"untracked.txt"));
+}
+
+#[test]
+fn changed_files_empty_output_is_clean_and_excludes_untracked_files() {
+    let repo = git_repo();
+    let root = repo.path();
+    std::fs::write(root.join("tracked.txt"), "tracked\n").unwrap();
+    git(root, &["add", "--", "tracked.txt"]);
+    git(root, &["commit", "-q", "-m", "base"]);
+    git(root, &["switch", "-q", "-c", "feature"]);
+    std::fs::write(root.join("untracked.txt"), "untracked\n").unwrap();
+
+    for args in [
+        ["changed-files"].as_slice(),
+        ["changed-files", "--null"].as_slice(),
+    ] {
+        let out = flint_with_env(args, root, &[]);
+        assert!(out.status.success(), "{:?}", combined_output(&out));
+        assert!(out.stdout.is_empty(), "unexpected stdout: {:?}", out.stdout);
+        assert!(out.stderr.is_empty(), "unexpected stderr: {:?}", out.stderr);
+    }
+}
+
 /// Runs all fixture cases under tests/cases/.
 /// Each case is a directory containing:
 ///   files/     — files to copy into the repo and stage

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -184,6 +184,18 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
     );
     assert_eq!(from_rev.stdout, out.stdout);
 
+    let cli_precedence = flint_with_env(
+        &["changed-files", "--null", "--new-from-rev", base.trim()],
+        root,
+        &[("FLINT_NEW_FROM_REV", "missing-ref")],
+    );
+    assert!(
+        cli_precedence.status.success(),
+        "{:?}",
+        combined_output(&cli_precedence)
+    );
+    assert_eq!(cli_precedence.stdout, out.stdout);
+
     let env_options = flint_with_env(
         &["changed-files", "--null"],
         root,
@@ -236,6 +248,52 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
     );
     assert!(!full_paths.iter().any(|path| *path == b"deleted.txt"));
     assert!(!full_paths.iter().any(|path| *path == b"untracked.txt"));
+
+    let filtered = flint_with_env(
+        &[
+            "changed-files",
+            "--full",
+            "--null",
+            "--include",
+            "*.txt",
+            "--include",
+            "README.md",
+            "--exclude",
+            "space*",
+        ],
+        root,
+        &[],
+    );
+    assert!(
+        filtered.status.success(),
+        "{:?}",
+        combined_output(&filtered)
+    );
+    let filtered_paths = filtered
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    assert!(filtered_paths.iter().any(|path| *path == b"committed.txt"));
+    assert!(!filtered_paths.iter().any(|path| *path == b"space name.txt"));
+    assert!(!filtered_paths.iter().any(|path| *path == b"README.md"));
+    assert!(!filtered_paths.iter().any(|path| *path == b"generated.txt"));
+
+    let no_match = flint_with_env(
+        &["changed-files", "--include", "does-not-exist/**", "--null"],
+        root,
+        &[],
+    );
+    assert!(
+        no_match.status.success(),
+        "{:?}",
+        combined_output(&no_match)
+    );
+    assert!(no_match.stdout.is_empty());
+
+    let invalid = flint_with_env(&["changed-files", "--include", "[", "--null"], root, &[]);
+    assert!(!invalid.status.success());
+    assert!(combined_output(&invalid).contains("invalid --include glob pattern"));
 }
 
 #[test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -119,18 +119,17 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
     git(root, &["switch", "-q", "-c", "feature"]);
 
     std::fs::write(root.join("committed.txt"), "committed\n").unwrap();
+    // Windows does not allow control characters (including newlines) in file
+    // names. Keep this case on platforms where the filesystem supports it so
+    // the NUL-delimited output remains covered there; the space-containing
+    // filename below still exercises safe machine-readable output on Windows.
+    #[cfg(not(windows))]
     std::fs::write(root.join("line\nbreak.txt"), "newline\n").unwrap();
     std::fs::write(root.join("space name.txt"), "space\n").unwrap();
-    git(
-        root,
-        &[
-            "add",
-            "--",
-            "committed.txt",
-            "line\nbreak.txt",
-            "space name.txt",
-        ],
-    );
+    let mut committed_paths = vec!["add", "--", "committed.txt", "space name.txt"];
+    #[cfg(not(windows))]
+    committed_paths.push("line\nbreak.txt");
+    git(root, &committed_paths);
     git(root, &["commit", "-q", "-m", "committed changes"]);
 
     std::fs::write(root.join("staged.txt"), "staged\n").unwrap();
@@ -145,13 +144,14 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
     assert!(out.status.success(), "{:?}", combined_output(&out));
     assert!(out.stderr.is_empty(), "unexpected stderr: {:?}", out.stderr);
 
-    let mut expected = [
+    let mut expected = vec![
         "committed.txt",
-        "line\nbreak.txt",
         "space name.txt",
         "staged.txt",
         "unstaged.txt",
     ];
+    #[cfg(not(windows))]
+    expected.push("line\nbreak.txt");
     expected.sort_unstable();
     let expected = expected.join("\0") + "\0";
     assert_eq!(out.stdout, expected.as_bytes());
@@ -162,13 +162,14 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
         "{:?}",
         combined_output(&line_output)
     );
-    let mut expected_lines = [
+    let mut expected_lines = vec![
         "committed.txt",
-        "line\nbreak.txt",
         "space name.txt",
         "staged.txt",
         "unstaged.txt",
     ];
+    #[cfg(not(windows))]
+    expected_lines.push("line\nbreak.txt");
     expected_lines.sort_unstable();
     let expected_lines = expected_lines.join("\n") + "\n";
     assert_eq!(line_output.stdout, expected_lines.as_bytes());
@@ -224,6 +225,7 @@ fn changed_files_uses_changed_file_semantics_and_is_deterministic() {
         .collect::<Vec<_>>();
     assert!(full_paths.windows(2).all(|pair| pair[0] < pair[1]));
     assert!(full_paths.iter().any(|path| *path == b"committed.txt"));
+    #[cfg(not(windows))]
     assert!(full_paths.iter().any(|path| *path == b"line\nbreak.txt"));
     assert!(full_paths.iter().any(|path| *path == b"space name.txt"));
     assert!(!full_paths.iter().any(|path| *path == b"generated.txt"));


### PR DESCRIPTION
## Summary

- add `flint changed-files` to expose Flint's Git-aware file selection
- document the command and integration patterns in the CLI reference and a dedicated guide
- add end-to-end coverage for changed-file semantics, revision overrides, filtering, deterministic output, and NUL-delimited paths

## Motivation

Repositories often orchestrate formatters and other tools outside Flint. For example, a `mise run format` task may need to invoke Spotless only when Scala, Groovy, or miscellaneous files changed, while still using Flint for Java, Kotlin, and other checks. Before this command, that caller had to duplicate Flint's Git logic and could drift from `flint run`.

`flint changed-files` provides one canonical, generic file set. Callers retain tool-specific filtering: Flint does not need to know which files belong to Spotless or another formatter. This is intended for external formatter orchestration, hooks, editor integrations, and repository tasks that need Flint's exact changed-file semantics without running linters.

## Semantics

Without `--full`, the command returns the union of:

- committed changes in the three-dot range from the merge base with the configured base branch to `HEAD`;
- staged index changes; and
- unstaged worktree changes.

Untracked files are excluded until staged. `--full` returns all eligible tracked files. Deleted or nonexistent paths, `linguist-generated` paths, Flint-managed files, and paths excluded by `flint.toml` are omitted. Results are repository-relative and deterministic.

`--new-from-rev`, `--to-ref`, `FLINT_NEW_FROM_REV`, and `FLINT_TO_REF` provide revision control matching `flint run`. `--null` emits NUL-delimited paths for safe machine-readable consumption. Flint currently represents Git paths as UTF-8 strings, so invalid non-UTF-8 bytes are lossily converted; `--null` protects whitespace and newlines but cannot preserve those arbitrary bytes.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `mise run test` (310 unit tests and 13 end-to-end tests passed; 1 ignored)
- `cargo fmt -- --check`
- `git diff --check`
