### PR TITLE
fix(renovate-deps): keep invalid action values

### DIFF
--- a/src/linters/renovate_deps/snapshot.rs
+++ b/src/linters/renovate_deps/snapshot.rs
@@ -3,12 +3,6 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
 
 const PACKAGE_FILES_MSGS: &[&str] = &["Extracted dependencies", "packageFiles with updates"];
-// `invalid-version` is intentionally NOT filtered: it is set at lookup time when
-// Renovate's versioning rejects the resolved `currentVersion` (e.g. mise.lock
-// forwarding `temurin-*` as currentVersion for java-jdk). The dep is still
-// declared in the config and must remain tracked; filtering it here caused
-// `--fix` (lookup) to silently drop deps that verify (extract) keeps.
-const SKIP_REASONS: &[&str] = &["contains-variable", "invalid-value"];
 
 /// `{file_path: {manager: [dep_name, ...]}}` — all collections sorted.
 pub(crate) type DepFiles = BTreeMap<String, BTreeMap<String, Vec<String>>>;
@@ -167,7 +161,7 @@ pub(crate) fn extract_deps(
                 };
                 for dep in deps {
                     let skip_reason = dep.get("skipReason").and_then(|v| v.as_str());
-                    if SKIP_REASONS.contains(&skip_reason.unwrap_or("")) {
+                    if should_skip_dep(manager, skip_reason) {
                         continue;
                     }
                     let Some(dep_name) = dep.get("depName").and_then(|v| v.as_str()) else {
@@ -245,6 +239,19 @@ pub(crate) fn extract_deps(
         files,
         action_meta,
     })
+}
+
+fn should_skip_dep(manager: &str, skip_reason: Option<&str>) -> bool {
+    match skip_reason {
+        Some("contains-variable") => true,
+        // For GitHub Actions, lookup mode marks expression-based refs as
+        // invalid-value while extract mode keeps the dependency. It is still
+        // declared and must remain in both snapshots so fix is idempotent.
+        Some("invalid-value") => manager != "github-actions",
+        // invalid-version is likewise lookup-only and never removes a
+        // declared dependency from the stable snapshot.
+        _ => false,
+    }
 }
 
 /// Extract stable metadata for a reusable action from Renovate's dependency

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -300,6 +300,21 @@ fn filters_skip_reasons() {
 }
 
 #[test]
+fn github_action_invalid_value_is_kept() {
+    // Lookup marks GitHub Actions whose ref comes from an expression as
+    // invalid-value, while extract mode keeps the same dependency. Keeping it
+    // in both snapshots makes fix followed by verification idempotent.
+    let log = log(
+        r#"{"github-actions":[{"packageFile":".github/workflows/release.yml","deps":[{"depName":"sigstore/cosign","currentValue":"${{ env.COSIGN_VERSION }}","skipReason":"invalid-value"}]}]}"#,
+    );
+    let result = extract_deps(&log, &[]).unwrap();
+    assert_eq!(
+        result.files[".github/workflows/release.yml"]["github-actions"],
+        vec!["sigstore/cosign"]
+    );
+}
+
+#[test]
 fn invalid_version_is_kept() {
     // Lookup-time versioning failures (e.g. java-jdk `temurin-*` currentVersion
     // rejected by workarounds:javaLTSVersions regex) must not drop the dep.


### PR DESCRIPTION
## What changed

- Keep GitHub Actions dependencies marked `skipReason: invalid-value` during Renovate lookup.
- Continue filtering `invalid-value` for other managers.
- Add regression coverage for expression-based action refs.

## Why

After #492, enabling the `github-actions` manager in `grafana/docker-otel-lgtm` exposed a fix/verify mismatch. Renovate extract mode kept `sigstore/cosign@${{ env.COSIGN_VERSION }}`, while lookup mode marked it `invalid-value`; Flint then dropped it only from the generated snapshot. The next verification immediately reported the snapshot as stale.

Keeping this declared GitHub Actions dependency in both modes makes snapshot generation idempotent without broadening the behavior for other managers.

## Validation

- `mise run lint:fix`
- `cargo test` — 325 unit tests and 13 E2E tests passed; one network test ignored
- Real `grafana/docker-otel-lgtm` run with `github-actions` enabled:
  - `flint run --full --fix renovate-deps`
  - `flint run --full renovate-deps` reports the snapshot is up to date
