### PR TITLE
ci: keep PR title check current after rebases

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,11 +5,13 @@ on:
     types:
       - opened
       - edited
+      - synchronize
+      - reopened
 permissions:
   pull-requests: read
 
 jobs:
-  lint:
+  pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: grafana/shared-workflows/actions/lint-pr-title@70c40e5b6522c854a55334124545261cae3d4c73 # lint-pr-title/v1.2.4


### PR DESCRIPTION
## Summary

- rerun the PR title workflow for synchronize and reopened events
- rename the job from `lint` to `pr-title` so it cannot share the regular lint workflow's required-check context

Without the synchronize trigger, a force-push or Renovate rebase replaces the commit carrying a failed title check without running the title check on the new head.

## Verification

- `mise run lint:fix`
- `mise run lint`

After this merges, add `pr-title` to the main branch ruleset's required status checks. Keeping that ruleset update until after merge avoids blocking existing pull requests whose base branch does not yet define the new context.
