### PR TITLE
fix: keep full file checks scoped to tracked files

### DIFF
--- a/docs/check-model.md
+++ b/docs/check-model.md
@@ -50,6 +50,26 @@ Some checks are exceptions:
 - **setup checks** such as `flint-setup` are special-purpose and may run even
   though they are not ordinary linter binaries
 
+## File-selection contract
+
+Flint owns file selection. File and files checks receive only eligible tracked
+paths selected by Flint, including in `--full` mode. A check that cannot obey
+this contract is an explicit exception and may inspect files beyond Flint's
+selected list.
+
+The exceptions are:
+
+- `cargo-fmt` and `cargo-clippy`, which need Cargo project context
+- `golangci-lint`, which needs Go package context (and uses `--new-from-rev` to
+  scope reported findings to changed code)
+- `kube-linter`, which recursively selects configured manifests
+- `renovate-deps`, which examines fixed dependency metadata paths
+- `flint-setup`, which checks its fixed setup files (`mise.toml` and
+  `flint.toml`)
+
+These exceptions are intentional and should be called out when adding a new
+check that cannot receive Flint's selected paths.
+
 ## Two execution models
 
 Flint supports two main kinds of checks.
@@ -73,15 +93,6 @@ Template checks declare:
   - **file**: one invocation per file
   - **files**: one invocation with a file list
   - **project**: one invocation with no file arguments
-
-Flint owns file selection: file and files checks receive only eligible tracked
-paths selected by Flint, including in `--full` mode. Checks that cannot obey this
-contract are explicit exceptions and may inspect files beyond Flint's selected
-list. The current exceptions are `cargo-fmt`, `cargo-clippy`, `flint-setup`,
-`golangci-lint`, `kube-linter`, and `renovate-deps`. Cargo and golangci-lint
-need package context; kube-linter recursively selects configured manifests;
-renovate-deps examines fixed dependency metadata paths; and flint-setup checks
-its fixed setup files (`mise.toml` and `flint.toml`).
 
 This is the simplest model when a tool is already a good CLI and Flint mainly
 needs to handle:

--- a/docs/check-model.md
+++ b/docs/check-model.md
@@ -74,6 +74,12 @@ Template checks declare:
   - **files**: one invocation with a file list
   - **project**: one invocation with no file arguments
 
+Flint owns file selection: file and files checks receive only eligible tracked
+paths selected by Flint, including in `--full` mode. Project-scoped checks are
+explicit exceptions because some upstream CLIs require package-wide context.
+The current exceptions are `cargo-fmt`, `cargo-clippy`, and `golangci-lint`;
+they may inspect files beyond Flint's selected list when activated.
+
 This is the simplest model when a tool is already a good CLI and Flint mainly
 needs to handle:
 

--- a/docs/check-model.md
+++ b/docs/check-model.md
@@ -75,10 +75,13 @@ Template checks declare:
   - **project**: one invocation with no file arguments
 
 Flint owns file selection: file and files checks receive only eligible tracked
-paths selected by Flint, including in `--full` mode. Project-scoped checks are
-explicit exceptions because some upstream CLIs require package-wide context.
-The current exceptions are `cargo-fmt`, `cargo-clippy`, and `golangci-lint`;
-they may inspect files beyond Flint's selected list when activated.
+paths selected by Flint, including in `--full` mode. Checks that cannot obey this
+contract are explicit exceptions and may inspect files beyond Flint's selected
+list. The current exceptions are `cargo-fmt`, `cargo-clippy`, `flint-setup`,
+`golangci-lint`, `kube-linter`, and `renovate-deps`. Cargo and golangci-lint
+need package context; kube-linter recursively selects configured manifests;
+renovate-deps examines fixed dependency metadata paths; and flint-setup checks
+its fixed setup files (`mise.toml` and `flint.toml`).
 
 This is the simplest model when a tool is already a good CLI and Flint mainly
 needs to handle:

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -61,14 +61,17 @@ Invoked once per matched file.
 
 ### Scope: files
 
-Invoked once with all matched files as args; only changed files are passed.
+Invoked once with all Flint-selected files as args. This includes every
+eligible tracked file in `--full` mode.
 
 ### Scope: project
 
-Invoked once with no file args; for checks with patterns set (e.g.
-`cargo-clippy`), skipped entirely if no matching files changed, but runs on the
-whole project when it does run. `golangci-lint` is the exception — it uses
-`--new-from-rev` to scope analysis to changed code even within the project run.
+Invoked once with no file args; for checks with patterns set, skipped entirely
+if no matching files changed, but runs on the whole project when it does run.
+These are explicit exceptions to Flint's file-selection contract: `cargo-fmt`,
+`cargo-clippy`, and `golangci-lint` need project/package context that their CLIs
+cannot constrain to a path list. `golangci-lint` uses `--new-from-rev` to scope
+reported findings to changed code, but may still inspect the project.
 
 ### Scope: native
 

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -55,6 +55,11 @@ page with its behavior, configuration, and examples.
 
 ## Scopes
 
+Flint owns file selection: file and files checks receive only eligible tracked
+paths selected by Flint, including in `--full` mode. Some checks necessarily
+deviate because they need project context or perform their own discovery; see
+[the file-selection contract and authoritative exception list](check-model.md#file-selection-contract).
+
 ### Scope: file
 
 Invoked once per matched file.
@@ -69,18 +74,14 @@ every eligible tracked file.
 
 Invoked once with no file args; for checks with patterns set, skipped entirely
 if no matching files changed, but runs on the whole project when it does run.
-The template checks using this scope are explicit exceptions to Flint's
-file-selection contract: `cargo-fmt`, `cargo-clippy`, and `golangci-lint` need
-project/package context. `golangci-lint` uses `--new-from-rev` to scope reported
-findings to changed code, but may still inspect the project. Native
-project-wide exceptions are described below.
+Project-scoped checks are explicit exceptions to Flint's file-selection
+contract; see the authoritative exception list in
+[How Flint runs checks](check-model.md#file-selection-contract).
 
 ### Scope: native
 
 Implemented in-process rather than via a command template. Native checks declare
-whether they honor Flint's selected paths. Most do; `kube-linter`,
-`renovate-deps`, and `flint-setup` are explicit project-wide exceptions.
-Kube-linter recursively selects configured manifests; renovate-deps examines
-fixed dependency metadata paths; and flint-setup checks its fixed setup files.
+whether they honor Flint's selected paths. Most do; the explicit exceptions are
+listed in [How Flint runs checks](check-model.md#file-selection-contract).
 See [How Flint runs checks](check-model.md) for the higher-level model and when
 to choose native vs template checks.

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -61,21 +61,26 @@ Invoked once per matched file.
 
 ### Scope: files
 
-Invoked once with all Flint-selected files as args. This includes every
-eligible tracked file in `--full` mode.
+Invoked in one or more batches with Flint-selected files as args. Batches are
+used when the rendered command would be large. In `--full` mode, this includes
+every eligible tracked file.
 
 ### Scope: project
 
 Invoked once with no file args; for checks with patterns set, skipped entirely
 if no matching files changed, but runs on the whole project when it does run.
-These are explicit exceptions to Flint's file-selection contract: `cargo-fmt`,
-`cargo-clippy`, and `golangci-lint` need project/package context that their CLIs
-cannot constrain to a path list. `golangci-lint` uses `--new-from-rev` to scope
-reported findings to changed code, but may still inspect the project.
+The template checks using this scope are explicit exceptions to Flint's
+file-selection contract: `cargo-fmt`, `cargo-clippy`, and `golangci-lint` need
+project/package context. `golangci-lint` uses `--new-from-rev` to scope reported
+findings to changed code, but may still inspect the project. Native
+project-wide exceptions are described below.
 
 ### Scope: native
 
-Implemented in-process rather than via a command template. These checks may run
-without file arguments or use custom orchestration logic. See
-[How Flint runs checks](check-model.md) for the higher-level model and when to
-choose native vs template checks.
+Implemented in-process rather than via a command template. Native checks declare
+whether they honor Flint's selected paths. Most do; `kube-linter`,
+`renovate-deps`, and `flint-setup` are explicit project-wide exceptions.
+Kube-linter recursively selects configured manifests; renovate-deps examines
+fixed dependency metadata paths; and flint-setup checks its fixed setup files.
+See [How Flint runs checks](check-model.md) for the higher-level model and when
+to choose native vs template checks.

--- a/docs/linters/dotnet-format.md
+++ b/docs/linters/dotnet-format.md
@@ -14,9 +14,9 @@
 <!-- linter-metadata-end -->
 
 `dotnet-format` checks and formats C# code. For a normal changed-files run,
-Flint passes the changed paths to `dotnet format --include`. The paths are
-relative to the project root, as required by the .NET CLI. A full run omits
-`--include` and checks the entire solution or project:
+Flint passes the eligible tracked paths to `dotnet format --include`. The paths
+are relative to the project root, as required by the .NET CLI. A full run still
+passes the complete Flint-selected C# file list:
 
 ```bash
 flint run --full dotnet-format

--- a/docs/linters/ktlint.md
+++ b/docs/linters/ktlint.md
@@ -14,8 +14,9 @@
 <!-- linter-metadata-end -->
 
 `ktlint` lints and formats Kotlin source and script files. On a normal run,
-Flint passes only changed files to `ktlint`. A full run passes the project root
-instead, which is useful after changing ktlint rules:
+Flint passes only changed files to `ktlint`; a full run passes all eligible
+tracked Kotlin files. Flint retains ownership of file selection rather than
+asking KtLint to recursively scan the project:
 
 ```bash
 flint run --full ktlint

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -685,10 +685,6 @@ fn check_ktlint() -> Check {
         &["*.kt", "*.kts"],
     )
     .fix("ktlint --format --log-level=error {FILES}")
-    .full_cmd(
-        "ktlint --log-level=error {ROOT}",
-        "ktlint --format --log-level=error {ROOT}",
-    )
     .windows_java_jar()
     .formatter()
     .project_url(KTLINT_URL)
@@ -712,7 +708,6 @@ fn check_dotnet_format() -> Check {
         &["*.cs"],
     )
     .fix("dotnet format --include {RELFILES}")
-    .full_cmd("dotnet format --verify-no-changes", "dotnet format")
     .bin("dotnet")
     .mise_tool("dotnet")
     .toolchain()

--- a/src/registry/checks.rs
+++ b/src/registry/checks.rs
@@ -625,6 +625,7 @@ fn check_gofmt() -> Check {
 
 fn check_google_java_format() -> Check {
     Check::native(&google_java_format::CHECK_TYPE)
+        .flint_file_selection()
         .patterns(&["*.java"])
         .mise_tool("google-java-format")
         .formatter()
@@ -650,6 +651,7 @@ fn check_google_java_format() -> Check {
 
 fn check_regex_replace() -> Check {
     Check::native(&regex_replace::CHECK_TYPE)
+        .flint_file_selection()
         .fix_first()
         .activate_unconditionally()
         .status_hook(regex_replace::status)
@@ -725,6 +727,7 @@ fn check_dotnet_format() -> Check {
 
 fn check_lychee() -> Check {
     Check::native(&lychee::CHECK_TYPE)
+        .flint_file_selection()
         .project_url(LYCHEE_URL)
         .overview(
             OverviewSection::General,
@@ -753,6 +756,7 @@ fn check_renovate_deps() -> Check {
 
 fn check_license_header() -> Check {
     Check::native(&license_header::CHECK_TYPE)
+        .flint_file_selection()
         .activate_unconditionally()
         .status_hook(license_header::status)
         .overview(

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -12,14 +12,14 @@ pub use mise::{
 };
 pub use obsolete::{find_obsolete_key, find_unsupported_key, obsolete_keys, unsupported_keys};
 pub use resolve::binary_on_path;
-#[allow(unused_imports)]
+#[cfg(test)]
+pub use types::FileSelection;
 pub use types::{
     AdaptiveRelevanceContext, Category, Check, CheckKind, CheckTypeDef, ConfigBase, ConfigFile,
-    ConfigMatch, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy, FileSelection,
-    FixBehavior, InitHookContext, LinterConfig, LinterOutput, MissingComponentHint, NativeCheck,
-    NativeCheckDef, NativePrepareContext, NativeRunContext, NativeRunFuture,
-    NonverboseFailureOutputHook, PreparedNativeCheck, Scope, SetupOutcome, StatusContext,
-    WorkflowSetup,
+    ConfigMatch, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy, FixBehavior,
+    InitHookContext, LinterConfig, LinterOutput, MissingComponentHint, NativeCheck, NativeCheckDef,
+    NativePrepareContext, NativeRunContext, NativeRunFuture, NonverboseFailureOutputHook,
+    PreparedNativeCheck, Scope, SetupOutcome, StatusContext, WorkflowSetup,
 };
 
 /// Returns the explicit set of flint-managed tool keys that belong under the

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -12,12 +12,14 @@ pub use mise::{
 };
 pub use obsolete::{find_obsolete_key, find_unsupported_key, obsolete_keys, unsupported_keys};
 pub use resolve::binary_on_path;
+#[allow(unused_imports)]
 pub use types::{
     AdaptiveRelevanceContext, Category, Check, CheckKind, CheckTypeDef, ConfigBase, ConfigFile,
-    ConfigMatch, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy, FixBehavior,
-    InitHookContext, LinterConfig, LinterOutput, MissingComponentHint, NativeCheck, NativeCheckDef,
-    NativePrepareContext, NativeRunContext, NativeRunFuture, NonverboseFailureOutputHook,
-    PreparedNativeCheck, Scope, SetupOutcome, StatusContext, WorkflowSetup,
+    ConfigMatch, EditorconfigDirectiveStyle, EditorconfigLineLengthPolicy, FileSelection,
+    FixBehavior, InitHookContext, LinterConfig, LinterOutput, MissingComponentHint, NativeCheck,
+    NativeCheckDef, NativePrepareContext, NativeRunContext, NativeRunFuture,
+    NonverboseFailureOutputHook, PreparedNativeCheck, Scope, SetupOutcome, StatusContext,
+    WorkflowSetup,
 };
 
 /// Returns the explicit set of flint-managed tool keys that belong under the

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -263,6 +263,49 @@ fn version_ranges_must_not_be_mixed_with_unranged_entries() {
     }
 }
 
+#[test]
+fn ktlint_full_runs_keep_file_list_filtering() {
+    let check = builtin()
+        .into_iter()
+        .find(|check| check.name == "ktlint")
+        .expect("ktlint registry entry");
+    let crate::registry::CheckKind::Template {
+        check_cmd,
+        full_cmd,
+        ..
+    } = &check.kind
+    else {
+        panic!("ktlint must use a command template");
+    };
+
+    assert!(check_cmd.contains("{FILES}"));
+    assert!(full_cmd.is_empty(), "ktlint must not scan the project root");
+}
+
+#[test]
+fn project_wide_checks_are_explicit_file_selection_exceptions() {
+    use crate::registry::FileSelection;
+
+    let expected = ["cargo-clippy", "cargo-fmt", "golangci-lint"];
+    let mut exceptions: Vec<&str> = builtin()
+        .iter()
+        .filter(|check| check.file_selection == FileSelection::ProjectWide)
+        .map(|check| check.name)
+        .collect();
+    exceptions.sort_unstable();
+    assert_eq!(exceptions, expected);
+
+    for check in builtin() {
+        if let CheckKind::Template { full_cmd, .. } = check.kind {
+            assert!(
+                full_cmd.is_empty() || check.file_selection == FileSelection::ProjectWide,
+                "{} has an unscoped full command without declaring a project-wide exception",
+                check.name
+            );
+        }
+    }
+}
+
 fn normalized_command_prefix(check: &Check) -> Option<String> {
     let command = match &check.kind {
         crate::registry::CheckKind::Template {

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -286,7 +286,14 @@ fn ktlint_full_runs_keep_file_list_filtering() {
 fn project_wide_checks_are_explicit_file_selection_exceptions() {
     use crate::registry::FileSelection;
 
-    let expected = ["cargo-clippy", "cargo-fmt", "golangci-lint"];
+    let expected = [
+        "cargo-clippy",
+        "cargo-fmt",
+        "flint-setup",
+        "golangci-lint",
+        "kube-linter",
+        "renovate-deps",
+    ];
     let mut exceptions: Vec<&str> = builtin()
         .iter()
         .filter(|check| check.file_selection == FileSelection::ProjectWide)
@@ -296,9 +303,15 @@ fn project_wide_checks_are_explicit_file_selection_exceptions() {
     assert_eq!(exceptions, expected);
 
     for check in builtin() {
-        if let CheckKind::Template { full_cmd, .. } = check.kind {
+        if let CheckKind::Template {
+            full_cmd,
+            full_fix_cmd,
+            ..
+        } = check.kind
+        {
             assert!(
-                full_cmd.is_empty() || check.file_selection == FileSelection::ProjectWide,
+                (full_cmd.is_empty() && full_fix_cmd.is_empty())
+                    || check.file_selection == FileSelection::ProjectWide,
                 "{} has an unscoped full command without declaring a project-wide exception",
                 check.name
             );

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -16,6 +16,15 @@ pub enum Scope {
     Project,
 }
 
+/// Whether a check can be constrained to Flint's selected file list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSelection {
+    /// The check receives only paths selected by Flint.
+    Flint,
+    /// The upstream tool necessarily discovers files or packages itself.
+    ProjectWide,
+}
+
 impl Scope {
     pub fn name(self) -> &'static str {
         match self {
@@ -489,6 +498,8 @@ pub struct Check {
     pub version_range: Option<&'static str>,
     /// Glob patterns for matching files.
     pub patterns: &'static [&'static str],
+    /// Whether execution is constrained to Flint's selected paths.
+    pub file_selection: FileSelection,
     /// When any of these named checks are active, exclude their patterns from
     /// this check's file list. Used to avoid double-checking files that a
     /// dedicated formatter already owns.
@@ -688,6 +699,11 @@ impl Check {
             mise_tool_name: None,
             version_range: None,
             patterns,
+            file_selection: if scope == Scope::Project {
+                FileSelection::ProjectWide
+            } else {
+                FileSelection::Flint
+            },
             excludes_if_active: &[],
             linter_config: None,
             env: &[],
@@ -743,6 +759,7 @@ impl Check {
             mise_tool_name: None,
             version_range: None,
             patterns: &[],
+            file_selection: FileSelection::Flint,
             excludes_if_active: &[],
             linter_config: None,
             env: &[],

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -759,7 +759,7 @@ impl Check {
             mise_tool_name: None,
             version_range: None,
             patterns: &[],
-            file_selection: FileSelection::Flint,
+            file_selection: FileSelection::ProjectWide,
             excludes_if_active: &[],
             linter_config: None,
             env: &[],
@@ -796,6 +796,14 @@ impl Check {
     }
 
     // --- Modifiers ---
+
+    /// Declare that native preparation constrains execution to Flint's selected paths.
+    /// Native checks default to `ProjectWide` because their implementations may discover
+    /// files independently; opt in only when the implementation demonstrably uses the list.
+    pub fn flint_file_selection(mut self) -> Self {
+        self.file_selection = FileSelection::Flint;
+        self
+    }
 
     /// Override `bin_name` when the binary name differs from the check name
     /// (e.g. `ruff-format` invokes `ruff`).

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -981,6 +981,7 @@ mod tests {
                 full_fix_cmd: "",
                 scope: Scope::Files,
             },
+            file_selection: crate::registry::FileSelection::Flint,
             ..project_check(patterns)
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -930,6 +930,7 @@ mod tests {
             mise_tool_name: None,
             version_range: None,
             patterns,
+            file_selection: crate::registry::FileSelection::ProjectWide,
             excludes_if_active: &[],
             linter_config: None,
             env: &[],


### PR DESCRIPTION
## Summary
- keep KtLint and dotnet-format full runs constrained to Flint-selected tracked files
- document and declare project-wide file-selection exceptions
- add registry regression coverage for unscoped full commands

## Tests
- `mise run lint:fix`
- `cargo test` (338 passed, 13 passed, 1 ignored)