### PR TITLE
fix: reject renovate-deps in sparse checkouts

### DIFF
--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -612,6 +612,8 @@ async fn run_inner(
     verbose: bool,
     project_root: &Path,
 ) -> anyhow::Result<LinterOutput> {
+    ensure_complete_worktree(project_root)?;
+
     let config_path = resolve_renovate_config_path(project_root)?;
     let config_content = std::fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
@@ -636,6 +638,7 @@ async fn run_inner(
     }
     let mut generated =
         generate_snapshot(project_root, &config_path, &cfg.exclude_managers, dry_run).await?;
+    ensure_snapshot_not_truncated(project_root, committed.as_ref(), &generated)?;
     if !fix {
         if version_validation_needs_lookup(
             &generated,
@@ -736,6 +739,111 @@ async fn run_inner(
         stderr: vec![],
         setup_outcome: None,
     })
+}
+
+const SPARSE_CHECKOUT_REMEDIATION: &str =
+    "Disable sparse checkout with `git sparse-checkout disable`, then rerun renovate-deps.";
+
+/// Renovate discovers dependencies by walking the checkout on disk.  A sparse
+/// checkout therefore produces a valid-looking, but incomplete, snapshot. Do
+/// this check before invoking Renovate so `--fix` cannot replace a complete
+/// snapshot with one generated from only the materialized paths.
+fn ensure_complete_worktree(project_root: &Path) -> anyhow::Result<()> {
+    if sparse_checkout_detected(project_root) {
+        anyhow::bail!(
+            "renovate-deps requires a complete working tree; a sparse or partial working tree was detected. {SPARSE_CHECKOUT_REMEDIATION}"
+        );
+    }
+    Ok(())
+}
+
+/// Returns true when Git's effective sparse-checkout setting or its
+/// worktree-specific sparse-checkout file says that paths are omitted.
+///
+/// `git rev-parse --git-path` is important here: in a linked worktree the
+/// sparse-checkout file lives below `.git/worktrees/<name>`, not the common
+/// repository `.git/info` directory. All Git calls are best effort because a
+/// full run can still be useful in a directory that is not a Git checkout.
+fn sparse_checkout_detected(project_root: &Path) -> bool {
+    let config = std::process::Command::new("git")
+        .args(["config", "--bool", "core.sparseCheckout"])
+        .current_dir(project_root)
+        .output();
+    if let Ok(output) = config
+        && output.status.success()
+    {
+        return String::from_utf8_lossy(&output.stdout).trim() == "true";
+    }
+
+    // The config lookup above is the authoritative signal, including
+    // config.worktree. Keep the git-dir marker as a fallback for older Git
+    // versions and for checkouts whose config was moved between worktrees.
+    let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--git-path", "info/sparse-checkout"])
+        .current_dir(project_root)
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let path = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+    let path = if path.is_absolute() {
+        path
+    } else {
+        project_root.join(path)
+    };
+    path.is_file()
+}
+
+/// Protect comparison/fix mode if Git's config signal is unavailable or stale.
+/// Only report a mismatch when a path present in the committed snapshot is
+/// absent from Renovate's output *and* Git explicitly marks that path with the
+/// skip-worktree bit. A normal deleted/renamed dependency file cannot satisfy
+/// this guard, avoiding false positives for legitimate snapshot changes.
+fn ensure_snapshot_not_truncated(
+    project_root: &Path,
+    committed: Option<&Snapshot>,
+    generated: &Snapshot,
+) -> anyhow::Result<()> {
+    let Some(committed) = committed else {
+        return Ok(());
+    };
+    let missing: HashSet<_> = committed
+        .files
+        .keys()
+        .filter(|path| !generated.files.contains_key(*path))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let Ok(output) = std::process::Command::new("git")
+        .args(["ls-files", "-t", "-z"])
+        .current_dir(project_root)
+        .output()
+    else {
+        return Ok(());
+    };
+    if !output.status.success() {
+        return Ok(());
+    }
+
+    let sparse_missing = output.stdout.split(|byte| *byte == 0).any(|entry| {
+        let Some((status, path)) = entry.split_first() else {
+            return false;
+        };
+        *status == b'S'
+            && path.first() == Some(&b' ')
+            && missing.contains(&String::from_utf8_lossy(&path[1..]).into_owned())
+    });
+    if sparse_missing {
+        anyhow::bail!(
+            "renovate-deps snapshot generation omitted dependencies from sparse or partial paths. {SPARSE_CHECKOUT_REMEDIATION}"
+        );
+    }
+    Ok(())
 }
 
 fn version_validation_needs_lookup(

--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -751,7 +751,7 @@ const SPARSE_CHECKOUT_REMEDIATION: &str =
 fn ensure_complete_worktree(project_root: &Path) -> anyhow::Result<()> {
     if sparse_checkout_detected(project_root) {
         anyhow::bail!(
-            "renovate-deps requires a complete working tree; a sparse or partial working tree was detected. {SPARSE_CHECKOUT_REMEDIATION}"
+            "renovate-deps requires a complete working tree; a sparse checkout was detected. {SPARSE_CHECKOUT_REMEDIATION}"
         );
     }
     Ok(())
@@ -810,10 +810,11 @@ fn ensure_snapshot_not_truncated(
     let Some(committed) = committed else {
         return Ok(());
     };
-    let missing: HashSet<_> = committed
+    let missing: HashSet<String> = committed
         .files
         .keys()
         .filter(|path| !generated.files.contains_key(*path))
+        .cloned()
         .collect();
     if missing.is_empty() {
         return Ok(());
@@ -836,11 +837,11 @@ fn ensure_snapshot_not_truncated(
         };
         *status == b'S'
             && path.first() == Some(&b' ')
-            && missing.contains(&String::from_utf8_lossy(&path[1..]).into_owned())
+            && missing.contains(String::from_utf8_lossy(&path[1..]).as_ref())
     });
     if sparse_missing {
         anyhow::bail!(
-            "renovate-deps snapshot generation omitted dependencies from sparse or partial paths. {SPARSE_CHECKOUT_REMEDIATION}"
+            "renovate-deps snapshot generation omitted dependencies from sparse checkout paths. {SPARSE_CHECKOUT_REMEDIATION}"
         );
     }
     Ok(())

--- a/src/linters/renovate_deps/tests.rs
+++ b/src/linters/renovate_deps/tests.rs
@@ -1911,3 +1911,84 @@ fn extract_failure_snippet_falls_back_to_tail() {
     assert!(lines.last().unwrap().contains("line 29"));
     assert!(lines.first().unwrap().contains("line 10"));
 }
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn sparse_test_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    run_git(dir.path(), &["init", "-q", "-b", "main"]);
+    run_git(dir.path(), &["config", "user.email", "flint@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "flint"]);
+    std::fs::create_dir(dir.path().join("included")).unwrap();
+    std::fs::create_dir(dir.path().join("omitted")).unwrap();
+    std::fs::write(dir.path().join("included/deps.txt"), "included\n").unwrap();
+    std::fs::write(dir.path().join("omitted/deps.txt"), "omitted\n").unwrap();
+    run_git(dir.path(), &["add", "."]);
+    run_git(dir.path(), &["commit", "-qm", "initial"]);
+    dir
+}
+
+#[test]
+fn detects_sparse_checkout_using_effective_git_config() {
+    let repo = sparse_test_repo();
+    assert!(!sparse_checkout_detected(repo.path()));
+
+    run_git(repo.path(), &["sparse-checkout", "set", "included"]);
+    assert!(sparse_checkout_detected(repo.path()));
+
+    run_git(repo.path(), &["sparse-checkout", "disable"]);
+    assert!(!sparse_checkout_detected(repo.path()));
+}
+
+#[test]
+fn detects_sparse_checkout_in_linked_worktree_git_dir() {
+    let repo = sparse_test_repo();
+    let linked = repo.path().join("linked");
+    run_git(
+        repo.path(),
+        &["worktree", "add", "-q", linked.to_str().unwrap()],
+    );
+    assert!(!sparse_checkout_detected(&linked));
+
+    run_git(&linked, &["sparse-checkout", "set", "included"]);
+    assert!(sparse_checkout_detected(&linked));
+}
+
+#[test]
+fn mismatch_guard_rejects_omitted_snapshot_path_marked_skip_worktree() {
+    let repo = sparse_test_repo();
+    run_git(repo.path(), &["sparse-checkout", "set", "included"]);
+    let committed = snapshot(
+        &[("omitted", None, None)],
+        &[("omitted/deps.txt", &[("npm", &["omitted"])])],
+    );
+    let generated = Snapshot::default();
+
+    let error = ensure_snapshot_not_truncated(repo.path(), Some(&committed), &generated)
+        .expect_err("sparse snapshot should be rejected");
+    assert!(error.to_string().contains("git sparse-checkout disable"));
+}
+
+#[test]
+fn mismatch_guard_does_not_reject_normal_missing_snapshot_path() {
+    let repo = sparse_test_repo();
+    let committed = snapshot(
+        &[("omitted", None, None)],
+        &[("omitted/deps.txt", &[("npm", &["omitted"])])],
+    );
+    let generated = Snapshot::default();
+
+    ensure_snapshot_not_truncated(repo.path(), Some(&committed), &generated)
+        .expect("normal tracked files are not sparse paths");
+}


### PR DESCRIPTION
## Summary
- refuse renovate-deps snapshot generation in sparse or partial working trees
- detect effective and linked-worktree sparse-checkout state
- guard snapshot comparison with a skip-worktree mismatch check

## Validation
- `mise run lint:fix`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (344 passed, 1 ignored)

## Scope
Reviewed the lychee repo-wide working-tree behavior; no changes were needed because this safeguard is specific to Renovate snapshot generation.