### PR TITLE
feat: cache GitHub Renovate presets for offline checks

### DIFF
--- a/docs/linters/renovate-deps.md
+++ b/docs/linters/renovate-deps.md
@@ -62,10 +62,18 @@ linter explicitly bypass the skip.
 
 The new-file check works offline by matching changed paths against
 `managerFilePatterns` regexes/globs from the active config and any
-resolvable `extends` — inline entries, local file presets, and flint's own
-bundled `github>grafana/flint` preset. Remote presets from other sources
-can't be resolved without running Renovate, so those still only surface in
+resolvable `extends` — inline entries, local file presets, Flint's own
+bundled `github>grafana/flint` preset, and cached `github>owner/repo` presets.
+`flint init` warms the GitHub preset cache when `GITHUB_COM_TOKEN` or
+`GITHUB_TOKEN` is available; normal `flint run` never performs a network
+request. Cache-cold GitHub presets and presets from unsupported sources
+(`gitlab>`, npm, and HTTP URLs) are skipped, so those still only surface in
 CI.
+
+GitHub presets support the forms `github>owner/repo`,
+`github>owner/repo//path/to/preset.json`, and an optional `#ref` suffix. A
+preset without a path resolves `default.json`. Presets may extend other
+presets; resolution has a bounded depth and cycle guard.
 
 The "new tool not yet tracked" case (built-in managers, or a custom manager
 pattern flint couldn't resolve offline) is the typical reason a CI failure

--- a/src/linters/lychee.rs
+++ b/src/linters/lychee.rs
@@ -16,7 +16,7 @@ const GITHUB_BASE_REF_ENV: &str = "GITHUB_BASE_REF";
 const GITHUB_EVENT_NAME_ENV: &str = "GITHUB_EVENT_NAME";
 const GITHUB_HEAD_REF_ENV: &str = "GITHUB_HEAD_REF";
 const GITHUB_REPOSITORY_ENV: &str = "GITHUB_REPOSITORY";
-const LOCAL_CACHE_DIR: &str = ".lychee_cache";
+pub(crate) const LOCAL_CACHE_DIR: &str = ".lychee_cache";
 const LOCAL_CACHE_GITIGNORE: &str = "# Automatically created by flint for lychee local cache.\n*\n";
 const LOCAL_CACHE_OPT_OUT_COMMAND: &str = "mise set --global FLINT_LYCHEE_SKIP_LOCAL_CACHE=true";
 const LOCAL_CACHE_OPT_OUT_ENV: &str = "FLINT_LYCHEE_SKIP_LOCAL_CACHE";
@@ -560,7 +560,12 @@ fn prepare_cache_plan(project_root: &Path, preference: CachePreference) -> Prepa
     }
 }
 
-fn initialize_cache_dir(project_root: &Path) -> anyhow::Result<bool> {
+/// Create Flint's local cache directory and its ignore marker.
+///
+/// Other native checks may share this directory for local-only caches. Keeping
+/// the setup here means those caches get the same gitignore and lifecycle as
+/// lychee's cache.
+pub(crate) fn initialize_cache_dir(project_root: &Path) -> anyhow::Result<bool> {
     let cache_dir = project_root.join(LOCAL_CACHE_DIR);
     let existed = cache_dir.exists();
     std::fs::create_dir_all(&cache_dir)?;

--- a/src/linters/lychee.rs
+++ b/src/linters/lychee.rs
@@ -19,7 +19,7 @@ const GITHUB_REPOSITORY_ENV: &str = "GITHUB_REPOSITORY";
 pub(crate) const LOCAL_CACHE_DIR: &str = ".lychee_cache";
 const LOCAL_CACHE_GITIGNORE: &str = "# Automatically created by flint for lychee local cache.\n*\n";
 const LOCAL_CACHE_OPT_OUT_COMMAND: &str = "mise set --global FLINT_LYCHEE_SKIP_LOCAL_CACHE=true";
-const LOCAL_CACHE_OPT_OUT_ENV: &str = "FLINT_LYCHEE_SKIP_LOCAL_CACHE";
+pub(crate) const LOCAL_CACHE_OPT_OUT_ENV: &str = "FLINT_LYCHEE_SKIP_LOCAL_CACHE";
 const PR_HEAD_REPO_ENV: &str = "PR_HEAD_REPO";
 const PR_LINK_REMAP_ENV_VARS: &[&str] = &[
     GITHUB_REPOSITORY_ENV,

--- a/src/linters/renovate_deps/manager_patterns.rs
+++ b/src/linters/renovate_deps/manager_patterns.rs
@@ -7,31 +7,41 @@
 //! declares, without shelling out to Renovate.
 //!
 //! Patterns declared inline in the active config are always resolvable.
-//! Patterns that come from `extends` are only resolvable when:
-//! - the extend points at another file in the repo (`local>path` or a plain
-//!   relative path), or
-//! - the extend is `github>grafana/flint` (any/no version pin) — flint
-//!   bundles its own preset (`default.json`) at compile time, since it's the
-//!   one shipping that preset in the first place.
-//!
-//! Any other remote preset can't be resolved offline and is silently
-//! skipped; those changes fall back to the existing CI-only detection.
+//! Patterns that come from `extends` are resolved from local files, Flint's
+//! bundled preset, or a cached GitHub preset. GitHub presets are fetched by
+//! `flint init` when a token is available and cached in the same local cache
+//! directory used by lychee. A normal `flint run` only reads that cache: it
+//! never performs a network request. Cache-cold presets (and unsupported
+//! `gitlab>`, npm, or HTTP presets) are silently skipped and fall back to the
+//! existing CI-only detection.
 
 use std::collections::HashSet;
 use std::path::{Component, Path};
+use std::process::Stdio;
 
 use globset::GlobBuilder;
 use regex::Regex;
 
 const FLINT_DEFAULT_PRESET: &str = include_str!("../../../default.json");
 const FLINT_PRESET_EXTEND_PREFIX: &str = "github>grafana/flint";
+const GITHUB_PRESET_PREFIX: &str = "github>";
+const PRESET_CACHE_SUBDIR: &str = "renovate-presets";
+const MAX_PRESET_DEPTH: usize = 16;
+
+#[derive(Debug, Clone)]
+struct GithubPreset {
+    owner: String,
+    repo: String,
+    path: String,
+    reference: Option<String>,
+}
 
 pub(crate) fn bundled_extract_version_dep_names(
     project_root: &Path,
     config_content: &str,
 ) -> HashSet<String> {
     let mut visited = HashSet::new();
-    if !extends_flint_preset(project_root, config_content, &mut visited) {
+    if !extends_flint_preset(project_root, config_content, &mut visited, 0) {
         return HashSet::new();
     }
 
@@ -56,15 +66,20 @@ fn extends_flint_preset(
     project_root: &Path,
     config_content: &str,
     visited: &mut HashSet<String>,
+    depth: usize,
 ) -> bool {
+    if depth >= MAX_PRESET_DEPTH {
+        return false;
+    }
     let Ok(config) = json5::from_str::<serde_json::Value>(config_content) else {
         return false;
     };
 
     extends_entries(&config).into_iter().any(|entry| {
         is_flint_preset_extend(entry)
-            || resolve_extend(project_root, entry, visited)
-                .is_some_and(|resolved| extends_flint_preset(project_root, &resolved, visited))
+            || resolve_extend(project_root, entry, visited).is_some_and(|resolved| {
+                extends_flint_preset(project_root, &resolved, visited, depth + 1)
+            })
     })
 }
 
@@ -76,7 +91,7 @@ pub(crate) fn changed_matches_manager_file_patterns(
     changed: &HashSet<String>,
 ) -> bool {
     let mut visited = HashSet::new();
-    let patterns = collect_patterns(project_root, config_content, &mut visited);
+    let patterns = collect_patterns(project_root, config_content, &mut visited, 0);
     patterns
         .iter()
         .any(|pattern| changed.iter().any(|path| pattern.is_match(path)))
@@ -119,6 +134,7 @@ fn collect_patterns(
     project_root: &Path,
     config_content: &str,
     visited: &mut HashSet<String>,
+    depth: usize,
 ) -> Vec<CompiledPattern> {
     let mut patterns = Vec::new();
     let Ok(parsed) = json5::from_str::<serde_json::Value>(config_content) else {
@@ -141,9 +157,18 @@ fn collect_patterns(
         }
     }
 
+    if depth >= MAX_PRESET_DEPTH {
+        return patterns;
+    }
+
     for entry in extends_entries(&parsed) {
         if let Some(resolved) = resolve_extend(project_root, entry, visited) {
-            patterns.extend(collect_patterns(project_root, &resolved, visited));
+            patterns.extend(collect_patterns(
+                project_root,
+                &resolved,
+                visited,
+                depth + 1,
+            ));
         }
     }
 
@@ -161,8 +186,9 @@ fn extends_entries(parsed: &serde_json::Value) -> Vec<&str> {
 }
 
 /// Resolves an `extends` entry to its config content, if we can do so
-/// offline. Returns `None` (and records nothing in `visited`) for entries we
-/// can't or have already resolved.
+/// offline. Entries that are unsupported, cache-cold, or already resolved
+/// return `None`; recognized entries are recorded in `visited` before reading
+/// so cycles cannot recurse indefinitely.
 fn resolve_extend(
     project_root: &Path,
     entry: &str,
@@ -173,6 +199,14 @@ fn resolve_extend(
             return None;
         }
         return Some(FLINT_DEFAULT_PRESET.to_string());
+    }
+
+    if let Some(preset) = parse_github_preset(entry) {
+        let key = github_preset_key(&preset);
+        if !visited.insert(key) {
+            return None;
+        }
+        return read_cached_github_preset(project_root, &preset);
     }
 
     let rel_path = entry.strip_prefix("local>").unwrap_or(entry);
@@ -195,6 +229,204 @@ fn resolve_extend(
     std::fs::read_to_string(&candidate).ok()
 }
 
+/// Fetches cache-cold GitHub presets for `flint init`. This is intentionally
+/// not called by [`changed_matches_manager_file_patterns`], since relevance
+/// checks must remain offline and fast. Errors are ignored: a missing token,
+/// unavailable network, or unsupported preset should preserve the existing
+/// silent-skip behavior.
+pub(crate) fn warm_github_presets(project_root: &Path, config_content: &str) {
+    let mut visited = HashSet::new();
+    warm_config(project_root, config_content, &mut visited, 0);
+}
+
+fn warm_config(
+    project_root: &Path,
+    config_content: &str,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) {
+    if depth >= MAX_PRESET_DEPTH {
+        return;
+    }
+    let Ok(parsed) = json5::from_str::<serde_json::Value>(config_content) else {
+        return;
+    };
+
+    for entry in extends_entries(&parsed) {
+        if is_flint_preset_extend(entry) {
+            continue;
+        }
+        if let Some(preset) = parse_github_preset(entry) {
+            let key = github_preset_key(&preset);
+            if !visited.insert(key) {
+                continue;
+            }
+            if !cached_github_preset_exists(project_root, &preset) {
+                let _ = fetch_github_preset(project_root, &preset);
+            }
+            if let Some(resolved) = read_cached_github_preset(project_root, &preset) {
+                warm_config(project_root, &resolved, visited, depth + 1);
+            }
+            continue;
+        }
+
+        if let Some(resolved) = resolve_extend(project_root, entry, visited) {
+            warm_config(project_root, &resolved, visited, depth + 1);
+        }
+    }
+}
+
+fn parse_github_preset(entry: &str) -> Option<GithubPreset> {
+    let rest = entry.strip_prefix(GITHUB_PRESET_PREFIX)?;
+    let (rest, reference) = rest
+        .split_once('#')
+        .map_or((rest, None), |(value, reference)| (value, Some(reference)));
+    let (repo_part, path) = rest
+        .split_once("//")
+        .map_or((rest, "default.json"), |(repo, path)| (repo, path));
+    let mut repo_parts = repo_part.split('/');
+    let owner = repo_parts.next()?;
+    let repo = repo_parts.next()?;
+    if repo_parts.next().is_some()
+        || owner.is_empty()
+        || repo.is_empty()
+        || path.is_empty()
+        || !valid_remote_component(owner)
+        || !valid_remote_component(repo)
+        || !path.split('/').all(valid_remote_component)
+        || reference.is_some_and(|value| value.is_empty() || value.contains('\0'))
+    {
+        return None;
+    }
+    Some(GithubPreset {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        path: path.to_string(),
+        reference: reference.map(ToOwned::to_owned),
+    })
+}
+
+fn valid_remote_component(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains('\0')
+        && !value.contains('\\')
+        && !value.contains(':')
+}
+
+fn github_preset_key(preset: &GithubPreset) -> String {
+    format!(
+        "github>{}/{}//{}#{}",
+        preset.owner,
+        preset.repo,
+        preset.path,
+        preset.reference.as_deref().unwrap_or("<default>")
+    )
+}
+
+fn github_preset_cache_path(project_root: &Path, preset: &GithubPreset) -> std::path::PathBuf {
+    let reference = preset.reference.as_deref().unwrap_or("<default>");
+    let path = preset
+        .path
+        .split('/')
+        .map(percent_encode)
+        .collect::<Vec<_>>()
+        .join("/");
+    project_root
+        .join(crate::linters::lychee::LOCAL_CACHE_DIR)
+        .join(PRESET_CACHE_SUBDIR)
+        .join(percent_encode(&preset.owner))
+        .join(percent_encode(&preset.repo))
+        .join(percent_encode(reference))
+        .join(path)
+}
+
+fn cached_github_preset_exists(project_root: &Path, preset: &GithubPreset) -> bool {
+    github_preset_cache_path(project_root, preset).is_file()
+}
+
+fn read_cached_github_preset(project_root: &Path, preset: &GithubPreset) -> Option<String> {
+    std::fs::read_to_string(github_preset_cache_path(project_root, preset)).ok()
+}
+
+fn fetch_github_preset(project_root: &Path, preset: &GithubPreset) -> anyhow::Result<()> {
+    let token = std::env::var(crate::linters::env::GITHUB_COM_TOKEN_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var(crate::linters::env::GITHUB_TOKEN_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+    let Some(token) = token else {
+        return Ok(());
+    };
+
+    let api_url = std::env::var("GITHUB_API_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "https://api.github.com".to_string());
+    let api_url = api_url.trim_end_matches('/');
+    let mut url = format!(
+        "{api_url}/repos/{}/{}/contents/{}",
+        preset.owner,
+        preset.repo,
+        preset
+            .path
+            .split('/')
+            .map(percent_encode)
+            .collect::<Vec<_>>()
+            .join("/")
+    );
+    if let Some(reference) = &preset.reference {
+        url.push_str("?ref=");
+        url.push_str(&percent_encode(reference));
+    }
+
+    let output = std::process::Command::new("curl")
+        .args([
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--max-time",
+            "10",
+            "--header",
+            "Accept: application/vnd.github.raw+json",
+            "--header",
+            "User-Agent: flint",
+            "--header",
+            &format!("Authorization: Bearer {token}"),
+            &url,
+        ])
+        .stderr(Stdio::null())
+        .output()?;
+    if !output.status.success() || output.stdout.is_empty() {
+        return Ok(());
+    }
+
+    let destination = github_preset_cache_path(project_root, preset);
+    if let Some(parent) = destination.parent() {
+        crate::linters::lychee::initialize_cache_dir(project_root)?;
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(destination, output.stdout)?;
+    Ok(())
+}
+
+fn percent_encode(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![byte as char]
+            }
+            byte => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
+}
+
 fn is_safe_local_extend_path(rel_path: &str) -> bool {
     if rel_path.is_empty() || rel_path.contains(':') {
         return false;
@@ -214,4 +446,146 @@ fn is_flint_preset_extend(entry: &str) -> bool {
         || entry
             .strip_prefix(FLINT_PRESET_EXTEND_PREFIX)
             .is_some_and(|rest| rest.starts_with('#'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn cache_preset(root: &Path, entry: &str, content: &str) {
+        let preset = parse_github_preset(entry).expect("valid GitHub preset");
+        let path = github_preset_cache_path(root, &preset);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn parses_github_preset_forms() {
+        let default = parse_github_preset("github>owner/repo").unwrap();
+        assert_eq!(default.owner, "owner");
+        assert_eq!(default.repo, "repo");
+        assert_eq!(default.path, "default.json");
+        assert_eq!(default.reference, None);
+
+        let nested = parse_github_preset("github>owner/repo//presets/base.json#v2").unwrap();
+        assert_eq!(nested.path, "presets/base.json");
+        assert_eq!(nested.reference.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn cached_github_default_and_nested_presets_are_resolved() {
+        let root = tempfile::tempdir().unwrap();
+        cache_preset(
+            root.path(),
+            "github>owner/repo",
+            r#"{ customManagers: [{ managerFilePatterns: ["**/*.yaml"] }] }"#,
+        );
+        cache_preset(
+            root.path(),
+            "github>owner/repo//presets/base.json#v2",
+            r#"{ customManagers: [{ managerFilePatterns: ["**/*.toml"] }] }"#,
+        );
+
+        assert!(changed_matches_manager_file_patterns(
+            root.path(),
+            r#"{ extends: ["github>owner/repo"] }"#,
+            &HashSet::from(["config/app.yaml".to_string()]),
+        ));
+        assert!(changed_matches_manager_file_patterns(
+            root.path(),
+            r#"{ extends: ["github>owner/repo//presets/base.json#v2"] }"#,
+            &HashSet::from(["mise.toml".to_string()]),
+        ));
+    }
+
+    #[test]
+    fn cached_remote_preset_recursion_stops_on_cycle() {
+        let root = tempfile::tempdir().unwrap();
+        cache_preset(
+            root.path(),
+            "github>owner/one",
+            r#"{ extends: ["github>owner/two"] }"#,
+        );
+        cache_preset(
+            root.path(),
+            "github>owner/two",
+            r#"{ extends: ["github>owner/one"], customManagers: [{ managerFilePatterns: ["**/*.yml"] }] }"#,
+        );
+
+        assert!(changed_matches_manager_file_patterns(
+            root.path(),
+            r#"{ extends: ["github>owner/one"] }"#,
+            &HashSet::from([".github/workflows/ci.yml".to_string()]),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn warm_github_presets_fetches_cache_cold_and_skips_cache_hit() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::{Mutex, OnceLock};
+
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let bin = tempfile::tempdir().unwrap();
+        let count = root.path().join("curl-count");
+        let args = root.path().join("curl-args");
+        let curl = bin.path().join("curl");
+        std::fs::write(
+            &curl,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nn=$(cat '{}' 2>/dev/null || printf 0)\nprintf '%s' $((n + 1)) > '{}'\nprintf '%s' '{{ customManagers: [{{ managerFilePatterns: [\\\"**/*.yaml\\\"] }}] }}'\n",
+                args.display(),
+                count.display(),
+                count.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&curl, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let old_path = std::env::var_os("PATH");
+        let old_token = std::env::var_os(crate::linters::env::GITHUB_TOKEN_ENV);
+        let old_api_url = std::env::var_os("GITHUB_API_URL");
+        let mut path = bin.path().as_os_str().to_os_string();
+        if let Some(old_path) = &old_path {
+            path.push(":");
+            path.push(old_path);
+        }
+        unsafe {
+            std::env::set_var("PATH", path);
+            std::env::set_var(crate::linters::env::GITHUB_TOKEN_ENV, "test-token");
+            std::env::set_var("GITHUB_API_URL", "https://api.example.test");
+        }
+
+        let config = r#"{ extends: ["github>owner/repo//presets/base.json#v1"] }"#;
+        warm_github_presets(root.path(), config);
+        let preset = parse_github_preset("github>owner/repo//presets/base.json#v1").unwrap();
+        assert!(github_preset_cache_path(root.path(), &preset).is_file());
+        assert_eq!(std::fs::read_to_string(&count).unwrap(), "1");
+        let request = std::fs::read_to_string(&args).unwrap();
+        assert!(request.contains(
+            "https://api.example.test/repos/owner/repo/contents/presets/base.json?ref=v1"
+        ));
+
+        // A warm cache is sufficient even with a token: no second API call is made.
+        warm_github_presets(root.path(), config);
+        assert_eq!(std::fs::read_to_string(&count).unwrap(), "1");
+
+        unsafe {
+            match old_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+            match old_token {
+                Some(value) => std::env::set_var(crate::linters::env::GITHUB_TOKEN_ENV, value),
+                None => std::env::remove_var(crate::linters::env::GITHUB_TOKEN_ENV),
+            }
+            match old_api_url {
+                Some(value) => std::env::set_var("GITHUB_API_URL", value),
+                None => std::env::remove_var("GITHUB_API_URL"),
+            }
+        }
+    }
 }

--- a/src/linters/renovate_deps/manager_patterns.rs
+++ b/src/linters/renovate_deps/manager_patterns.rs
@@ -316,17 +316,21 @@ fn valid_remote_component(value: &str) -> bool {
 }
 
 fn github_preset_key(preset: &GithubPreset) -> String {
+    let reference = preset.reference.as_deref().map_or_else(
+        || "default".to_string(),
+        |reference| format!("ref:{reference}"),
+    );
     format!(
         "github>{}/{}//{}#{}",
-        preset.owner,
-        preset.repo,
-        preset.path,
-        preset.reference.as_deref().unwrap_or("<default>")
+        preset.owner, preset.repo, preset.path, reference
     )
 }
 
 fn github_preset_cache_path(project_root: &Path, preset: &GithubPreset) -> std::path::PathBuf {
-    let reference = preset.reference.as_deref().unwrap_or("<default>");
+    let reference = preset.reference.as_deref().map_or_else(
+        || "default".to_string(),
+        |reference| format!("ref-{}", percent_encode(reference)),
+    );
     let path = preset
         .path
         .split('/')
@@ -338,7 +342,7 @@ fn github_preset_cache_path(project_root: &Path, preset: &GithubPreset) -> std::
         .join(PRESET_CACHE_SUBDIR)
         .join(percent_encode(&preset.owner))
         .join(percent_encode(&preset.repo))
-        .join(percent_encode(reference))
+        .join(reference)
         .join(path)
 }
 
@@ -351,6 +355,13 @@ fn read_cached_github_preset(project_root: &Path, preset: &GithubPreset) -> Opti
 }
 
 fn fetch_github_preset(project_root: &Path, preset: &GithubPreset) -> anyhow::Result<()> {
+    if crate::linters::env::env_truthy(
+        &|name| std::env::var(name).ok(),
+        crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV,
+    ) {
+        return Ok(());
+    }
+
     let token = std::env::var(crate::linters::env::GITHUB_COM_TOKEN_ENV)
         .ok()
         .filter(|value| !value.trim().is_empty())
@@ -393,7 +404,7 @@ fn fetch_github_preset(project_root: &Path, preset: &GithubPreset) -> anyhow::Re
             "--max-time",
             "10",
             "--header",
-            "Accept: application/vnd.github.raw+json",
+            "Accept: application/vnd.github.raw",
             "--header",
             "User-Agent: flint",
             "--header",
@@ -474,6 +485,19 @@ mod tests {
     }
 
     #[test]
+    fn implicit_default_ref_cannot_collide_with_explicit_ref() {
+        let root = tempfile::tempdir().unwrap();
+        let implicit = parse_github_preset("github>owner/repo").unwrap();
+        let explicit = parse_github_preset("github>owner/repo#<default>").unwrap();
+
+        assert_ne!(github_preset_key(&implicit), github_preset_key(&explicit));
+        assert_ne!(
+            github_preset_cache_path(root.path(), &implicit),
+            github_preset_cache_path(root.path(), &explicit)
+        );
+    }
+
+    #[test]
     fn cached_github_default_and_nested_presets_are_resolved() {
         let root = tempfile::tempdir().unwrap();
         cache_preset(
@@ -548,6 +572,7 @@ mod tests {
         let old_path = std::env::var_os("PATH");
         let old_token = std::env::var_os(crate::linters::env::GITHUB_TOKEN_ENV);
         let old_api_url = std::env::var_os("GITHUB_API_URL");
+        let old_opt_out = std::env::var_os(crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV);
         let mut path = bin.path().as_os_str().to_os_string();
         if let Some(old_path) = &old_path {
             path.push(":");
@@ -557,6 +582,7 @@ mod tests {
             std::env::set_var("PATH", path);
             std::env::set_var(crate::linters::env::GITHUB_TOKEN_ENV, "test-token");
             std::env::set_var("GITHUB_API_URL", "https://api.example.test");
+            std::env::remove_var(crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV);
         }
 
         let config = r#"{ extends: ["github>owner/repo//presets/base.json#v1"] }"#;
@@ -568,9 +594,20 @@ mod tests {
         assert!(request.contains(
             "https://api.example.test/repos/owner/repo/contents/presets/base.json?ref=v1"
         ));
+        assert!(request.contains("Accept: application/vnd.github.raw\n"));
+        assert!(request.contains("User-Agent: flint\n"));
 
         // A warm cache is sufficient even with a token: no second API call is made.
         warm_github_presets(root.path(), config);
+        assert_eq!(std::fs::read_to_string(&count).unwrap(), "1");
+
+        // Opting out prevents warming but does not alter the cache-read path.
+        std::fs::remove_file(github_preset_cache_path(root.path(), &preset)).unwrap();
+        unsafe {
+            std::env::set_var(crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV, "true");
+        }
+        warm_github_presets(root.path(), config);
+        assert!(!github_preset_cache_path(root.path(), &preset).exists());
         assert_eq!(std::fs::read_to_string(&count).unwrap(), "1");
 
         unsafe {
@@ -585,6 +622,12 @@ mod tests {
             match old_api_url {
                 Some(value) => std::env::set_var("GITHUB_API_URL", value),
                 None => std::env::remove_var("GITHUB_API_URL"),
+            }
+            match old_opt_out {
+                Some(value) => {
+                    std::env::set_var(crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV, value)
+                }
+                None => std::env::remove_var(crate::linters::lychee::LOCAL_CACHE_OPT_OUT_ENV),
             }
         }
     }

--- a/src/linters/renovate_deps/manager_patterns.rs
+++ b/src/linters/renovate_deps/manager_patterns.rs
@@ -27,6 +27,7 @@ const FLINT_PRESET_EXTEND_PREFIX: &str = "github>grafana/flint";
 const GITHUB_PRESET_PREFIX: &str = "github>";
 const PRESET_CACHE_SUBDIR: &str = "renovate-presets";
 const MAX_PRESET_DEPTH: usize = 16;
+const GITHUB_API_VERSION: &str = "2026-03-10";
 
 #[derive(Debug, Clone)]
 struct GithubPreset {
@@ -406,7 +407,9 @@ fn fetch_github_preset(project_root: &Path, preset: &GithubPreset) -> anyhow::Re
             "--header",
             "Accept: application/vnd.github.raw",
             "--header",
-            "User-Agent: flint",
+            &format!("User-Agent: flint/{}", env!("CARGO_PKG_VERSION")),
+            "--header",
+            &format!("X-GitHub-Api-Version: {GITHUB_API_VERSION}"),
             "--header",
             &format!("Authorization: Bearer {token}"),
             &url,
@@ -595,7 +598,11 @@ mod tests {
             "https://api.example.test/repos/owner/repo/contents/presets/base.json?ref=v1"
         ));
         assert!(request.contains("Accept: application/vnd.github.raw\n"));
-        assert!(request.contains("User-Agent: flint\n"));
+        assert!(request.contains(&format!(
+            "User-Agent: flint/{}\n",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(request.contains("X-GitHub-Api-Version: 2026-03-10\n"));
 
         // A warm cache is sufficient even with a token: no second API call is made.
         warm_github_presets(root.path(), config);

--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -6,7 +6,7 @@ use std::process::Stdio;
 use self::action_validation::validate_lookup_action_warnings;
 use self::install_patch::configure_extract_workaround_env;
 use self::manager_patterns::{
-    bundled_extract_version_dep_names, changed_matches_manager_file_patterns,
+    bundled_extract_version_dep_names, changed_matches_manager_file_patterns, warm_github_presets,
 };
 use self::mise_normalize::patch_semver_equivalent_mise_values;
 use self::rules::{
@@ -109,6 +109,13 @@ pub(crate) fn init(ctx: &dyn InitHookContext) -> anyhow::Result<bool> {
     } else {
         false
     };
+    if let Some(path) = find_renovate_config(ctx.project_root())
+        && let Ok(content) = std::fs::read_to_string(path)
+    {
+        // Warm remote preset cache only during explicit init. Relevance checks
+        // and normal runs remain strictly offline.
+        warm_github_presets(ctx.project_root(), &content);
+    }
     let preset_changed = patch_renovate_preset(ctx.project_root())?;
     Ok(config_changed || preset_changed)
 }


### PR DESCRIPTION
## Summary

- Resolve `github>owner/repo` Renovate presets from a local cache during relevance checks.
- Warm cache-cold presets only during explicit `flint init`, using the GitHub contents API and the existing `.lychee_cache` lifecycle.
- Keep normal `flint run` offline and cache-only; cache misses silently retain the existing CI fallback.

Supported preset syntax:

- `github>owner/repo`
- `github>owner/repo//path/to/preset.json`
- Optional `#ref` on either form; no path defaults to `default.json`.

Nested presets are supported with a bounded recursion depth and cycle guard. Unsupported `gitlab>`, npm-hosted, and HTTP presets remain skipped. Remote cache path components are encoded for cross-platform safety.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (343 passed, 1 ignored before final mocked-fetch test)
- `cargo test manager_patterns` (4 passed, including mocked API fetch/cache-hit behavior)
