### PR TITLE
fix(lychee): prioritize PR remaps

### DIFF
--- a/src/linters/lychee.rs
+++ b/src/linters/lychee.rs
@@ -610,9 +610,17 @@ async fn build_remap_args(project_root: &Path) -> Vec<String> {
     }
     let server = github_server_url();
     let raw_base = raw_content_base(&server);
-    let mut args = build_global_github_args(&server, &raw_base);
-    args.extend(build_branch_remap_args(project_root, &server, &raw_base).await);
-    args
+    merge_remap_args(
+        build_branch_remap_args(project_root, &server, &raw_base).await,
+        build_global_github_args(&server, &raw_base),
+    )
+}
+
+/// Combines remaps in lychee's matching order: PR-specific rules must win over
+/// the global GitHub fallbacks for base-branch blob URLs.
+fn merge_remap_args(mut branch_args: Vec<String>, global_args: Vec<String>) -> Vec<String> {
+    branch_args.extend(global_args);
+    branch_args
 }
 
 fn build_global_github_args(server: &str, raw_base: &str) -> Vec<String> {
@@ -834,6 +842,24 @@ mod tests {
         );
         assert!(file_list.len() > 32_767);
         assert_eq!(file_list.split(|byte| *byte == b'\n').count(), 401);
+    }
+
+    #[test]
+    fn pr_remaps_precede_global_github_remaps() {
+        let remaps = merge_remap_args(
+            vec!["--remap".to_string(), "pr-branch-remap".to_string()],
+            vec!["--remap".to_string(), "global-github-remap".to_string()],
+        );
+
+        assert_eq!(
+            remaps,
+            [
+                "--remap",
+                "pr-branch-remap",
+                "--remap",
+                "global-github-remap"
+            ]
+        );
     }
 
     #[test]

--- a/tests/lychee-pr-branch-only.md
+++ b/tests/lychee-pr-branch-only.md
@@ -1,0 +1,4 @@
+# Lychee PR branch-only link target
+
+This file exists to verify that PR-aware lychee remaps check files introduced
+by the pull request rather than the base branch.

--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -26,6 +26,13 @@ these links verify that each remap rule works correctly during CI.
 
 - [LICENSE](https://github.com/grafana/flint/blob/main/LICENSE)
 
+## Branch-only blob URL — remapped to the PR working tree
+
+This target does not exist on `main`. In a PR, this link must resolve to the
+working-tree copy rather than the global raw-content remap for `main`.
+
+- [PR-only link target](https://github.com/grafana/flint/blob/main/tests/lychee-pr-branch-only.md)
+
 ## Tree URLs — remapped to PR branch
 
 - [tasks/lint directory](https://github.com/grafana/flint/tree/main/tasks/lint)


### PR DESCRIPTION
## Summary
- emit PR-specific lychee remaps before global GitHub fallbacks
- cover a blob link targeting a file introduced by the PR

## Validation
- `FLINT_CASES=lychee cargo test cases`
- `mise run lint:fix`
- `mise run lint`
- `cargo test`