### PR TITLE
feat(checker): expose runner-agnostic dependency and link checks

### DIFF
--- a/src/linters/renovate_deps/mod.rs
+++ b/src/linters/renovate_deps/mod.rs
@@ -85,6 +85,30 @@ impl PreparedNativeCheck for PreparedRenovateDeps {
     }
 }
 
+/// Runs renovate-deps only when the caller-selected paths are relevant.
+///
+/// This is the runner-agnostic boundary used by `flint checker renovate-deps`:
+/// callers own selection, while Flint owns the check's project-wide Renovate
+/// extraction and snapshot comparison. It deliberately performs no Git file
+/// discovery.
+pub async fn run_selected(
+    cfg: &RenovateDepsConfig,
+    fix: bool,
+    verbose: bool,
+    project_root: &Path,
+    file_list: &FileList,
+) -> LinterOutput {
+    if !is_relevant(file_list, project_root) {
+        return LinterOutput {
+            ok: true,
+            stdout: vec![],
+            stderr: vec![],
+            setup_outcome: None,
+        };
+    }
+    run(cfg, fix, verbose, project_root).await
+}
+
 pub async fn run(
     cfg: &RenovateDepsConfig,
     fix: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,8 @@ struct CheckerArgs {
 enum CheckerCommand {
     /// Verify Renovate's dependency snapshot for the supplied paths.
     RenovateDeps(RenovateDepsCheckerArgs),
+    /// Check links in caller-selected files, plus repository-wide local links in CI.
+    Lychee(LycheeCheckerArgs),
 }
 
 #[derive(Args, Debug)]
@@ -164,6 +166,18 @@ struct RenovateDepsCheckerArgs {
     /// Show Renovate's diagnostic output.
     #[arg(long)]
     verbose: bool,
+}
+
+#[derive(Args, Debug)]
+struct LycheeCheckerArgs {
+    /// Read newline-delimited repository-relative paths from PATH, or stdin for "-".
+    /// The final line does not need a trailing newline.
+    #[arg(long, value_name = "PATH", conflicts_with = "files")]
+    files_from: Option<String>,
+
+    /// Repository-relative paths selected by the caller.
+    #[arg(value_name = "FILE")]
+    files: Vec<PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -290,30 +304,51 @@ async fn main() -> Result<()> {
 }
 
 async fn run_checker(args: CheckerArgs, project_root: &Path, config_dir: &Path) -> Result<()> {
-    match args.command {
+    let cfg = config::load(config_dir)?;
+    let (name, out) = match args.command {
         CheckerCommand::RenovateDeps(args) => {
             let selected = read_checker_files(args.files_from.as_deref(), args.files)?;
             let file_list = checker_file_list(project_root, selected)?;
-            let cfg = config::load(config_dir)?;
-            let out = linters::renovate_deps::run_selected(
-                &cfg.checks.renovate_deps,
-                args.fix,
-                args.verbose,
-                project_root,
-                &file_list,
+            (
+                "renovate-deps",
+                linters::renovate_deps::run_selected(
+                    &cfg.checks.renovate_deps,
+                    args.fix,
+                    args.verbose,
+                    project_root,
+                    &file_list,
+                )
+                .await,
             )
-            .await;
-            let mut message = out.stdout;
-            message.extend(out.stderr);
-            let sarif = checker_sarif(out.ok, &message);
-            serde_json::to_writer_pretty(std::io::stdout(), &sarif)?;
-            println!();
-            if !out.ok {
-                std::process::exit(1);
-            }
-            Ok(())
         }
+        CheckerCommand::Lychee(args) => {
+            let selected = read_checker_files(args.files_from.as_deref(), args.files)?;
+            let mut file_list = checker_file_list(project_root, selected)?;
+            // The caller has already made a diff selection. Retain diff mode so
+            // Flint's CI local-link follow-up still runs, without Git discovery.
+            file_list.merge_base = Some("caller-selected".to_string());
+            (
+                "lychee",
+                linters::lychee::run(
+                    &cfg.checks.lychee,
+                    &cfg.settings,
+                    &file_list,
+                    project_root,
+                    config_dir,
+                )
+                .await,
+            )
+        }
+    };
+    let mut message = out.stdout;
+    message.extend(out.stderr);
+    let sarif = checker_sarif(name, out.ok, &message);
+    serde_json::to_writer_pretty(std::io::stdout(), &sarif)?;
+    println!();
+    if !out.ok {
+        std::process::exit(1);
     }
+    Ok(())
 }
 
 fn read_checker_files(files_from: Option<&str>, files: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
@@ -366,12 +401,12 @@ fn checker_file_list(project_root: &Path, selected: Vec<PathBuf>) -> Result<file
     })
 }
 
-fn checker_sarif(ok: bool, message: &[u8]) -> serde_json::Value {
+fn checker_sarif(name: &str, ok: bool, message: &[u8]) -> serde_json::Value {
     let results = if ok {
         vec![]
     } else {
         vec![serde_json::json!({
-            "ruleId": "renovate-deps",
+            "ruleId": name,
             "level": "error",
             "message": { "text": String::from_utf8_lossy(message) },
         })]
@@ -380,7 +415,7 @@ fn checker_sarif(ok: bool, message: &[u8]) -> serde_json::Value {
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
         "version": "2.1.0",
         "runs": [{
-            "tool": { "driver": { "name": "flint", "informationUri": "https://github.com/grafana/flint", "rules": [{ "id": "renovate-deps", "name": "renovate-deps" }] } },
+            "tool": { "driver": { "name": "flint", "informationUri": "https://github.com/grafana/flint", "rules": [{ "id": name, "name": name }] } },
             "results": results,
         }],
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use clap::{Args, Parser, Subcommand};
 use registry::CheckKind;
 use runner::{CheckResult, RunContext as RunnerRunContext, RunOptions};
 use std::collections::HashSet;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 #[path = "main_baseline.rs"]
@@ -41,6 +41,8 @@ enum SubCommand {
     Run(RunArgs),
     /// Print the repository files selected by Flint's changed-file discovery.
     ChangedFiles(ChangedFilesArgs),
+    /// Run a Flint-owned check against caller-selected files.
+    Checker(CheckerArgs),
     /// List available linters and their status.
     Linters(LintersArgs),
     /// Set up linters in mise.toml for this project.
@@ -130,6 +132,38 @@ struct RunArgs {
     /// Linters to run (default: all discovered).
     /// Explicit names bypass the local relevance gate.
     linters: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+struct CheckerArgs {
+    #[command(subcommand)]
+    command: CheckerCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum CheckerCommand {
+    /// Verify Renovate's dependency snapshot for the supplied paths.
+    RenovateDeps(RenovateDepsCheckerArgs),
+}
+
+#[derive(Args, Debug)]
+struct RenovateDepsCheckerArgs {
+    /// Read newline-delimited repository-relative paths from PATH, or stdin for "-".
+    /// The final line does not need a trailing newline.
+    #[arg(long, value_name = "PATH", conflicts_with = "files")]
+    files_from: Option<String>,
+
+    /// Repository-relative paths selected by the caller.
+    #[arg(value_name = "FILE")]
+    files: Vec<PathBuf>,
+
+    /// Update the tracked dependency snapshot when it is stale.
+    #[arg(long)]
+    fix: bool,
+
+    /// Show Renovate's diagnostic output.
+    #[arg(long)]
+    verbose: bool,
 }
 
 #[derive(Args, Debug)]
@@ -223,6 +257,9 @@ async fn main() -> Result<()> {
                 files::apply_filters(&project_root, file_list, &args.include, &args.exclude)?;
             print_changed_files(&project_root, &file_list.files, args.null)?;
         }
+        SubCommand::Checker(args) => {
+            run_checker(args, &project_root, &config_dir).await?;
+        }
         SubCommand::Init(args) => {
             if args.only.is_empty() {
                 init::run(
@@ -250,6 +287,103 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn run_checker(args: CheckerArgs, project_root: &Path, config_dir: &Path) -> Result<()> {
+    match args.command {
+        CheckerCommand::RenovateDeps(args) => {
+            let selected = read_checker_files(args.files_from.as_deref(), args.files)?;
+            let file_list = checker_file_list(project_root, selected)?;
+            let cfg = config::load(config_dir)?;
+            let out = linters::renovate_deps::run_selected(
+                &cfg.checks.renovate_deps,
+                args.fix,
+                args.verbose,
+                project_root,
+                &file_list,
+            )
+            .await;
+            let mut message = out.stdout;
+            message.extend(out.stderr);
+            let sarif = checker_sarif(out.ok, &message);
+            serde_json::to_writer_pretty(std::io::stdout(), &sarif)?;
+            println!();
+            if !out.ok {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn read_checker_files(files_from: Option<&str>, files: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    match files_from {
+        Some("-") => {
+            let mut input = String::new();
+            std::io::stdin().read_to_string(&mut input)?;
+            Ok(input
+                .split('\n')
+                .filter(|line| !line.is_empty())
+                .map(PathBuf::from)
+                .collect())
+        }
+        Some(path) => Ok(std::fs::read_to_string(path)?
+            .split('\n')
+            .filter(|line| !line.is_empty())
+            .map(PathBuf::from)
+            .collect()),
+        None => Ok(files),
+    }
+}
+
+fn checker_file_list(project_root: &Path, selected: Vec<PathBuf>) -> Result<files::FileList> {
+    let mut files = Vec::with_capacity(selected.len());
+    let mut changed_paths = Vec::with_capacity(selected.len());
+    for path in selected {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            project_root.join(path)
+        };
+        let relative = path.strip_prefix(project_root).with_context(|| {
+            format!(
+                "checker file is outside the project root: {}",
+                path.display()
+            )
+        })?;
+        changed_paths.push(
+            relative
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+        );
+        files.push(path);
+    }
+    Ok(files::FileList {
+        files,
+        changed_paths,
+        merge_base: None,
+        full: false,
+    })
+}
+
+fn checker_sarif(ok: bool, message: &[u8]) -> serde_json::Value {
+    let results = if ok {
+        vec![]
+    } else {
+        vec![serde_json::json!({
+            "ruleId": "renovate-deps",
+            "level": "error",
+            "message": { "text": String::from_utf8_lossy(message) },
+        })]
+    };
+    serde_json::json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": { "driver": { "name": "flint", "informationUri": "https://github.com/grafana/flint", "rules": [{ "id": "renovate-deps", "name": "renovate-deps" }] } },
+            "results": results,
+        }],
+    })
 }
 
 fn print_changed_files(project_root: &Path, files: &[PathBuf], nul: bool) -> Result<()> {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1759,3 +1759,35 @@ fn checker_accepts_positional_repository_relative_paths() {
 
     assert!(out.status.success(), "{}", combined_output(&out));
 }
+
+#[test]
+fn checker_lychee_accepts_hk_stdin_selection_and_emits_sarif() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let repo = git_repo();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flint"))
+        .args(["checker", "lychee", "--files-from", "-"])
+        .env_remove("FLINT_CONFIG_DIR")
+        .env_remove("CI")
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn flint lychee checker");
+    child
+        .stdin
+        .take()
+        .expect("checker stdin")
+        .write_all(b"ignored.bin")
+        .unwrap();
+    let out = child.wait_with_output().expect("wait for flint checker");
+
+    assert!(out.status.success(), "{}", combined_output(&out));
+    let sarif: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(sarif["runs"][0]["results"], serde_json::json!([]));
+    assert_eq!(
+        sarif["runs"][0]["tool"]["driver"]["rules"][0]["id"],
+        "lychee"
+    );
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1717,3 +1717,45 @@ fn normalize_output(s: String, repo_str: &str, repo_canonical: &str) -> String {
     };
     s
 }
+
+#[test]
+fn checker_uses_caller_file_list_from_stdin_without_git_discovery() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let repo = tempfile::tempdir().expect("temp repo");
+    assert!(!repo.path().join(".git").exists());
+    std::fs::write(repo.path().join("renovate.json5"), "{}\n").unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_flint"))
+        .args(["checker", "renovate-deps", "--files-from", "-"])
+        .env_remove("FLINT_CONFIG_DIR")
+        .env_remove("CI")
+        .current_dir(repo.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn flint checker");
+    child
+        .stdin
+        .take()
+        .expect("checker stdin")
+        .write_all(b"README.md") // hk's join intentionally omits a final newline.
+        .unwrap();
+    let out = child.wait_with_output().expect("wait for flint checker");
+
+    assert!(out.status.success(), "{}", combined_output(&out));
+    let sarif: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(sarif["version"], "2.1.0");
+    assert_eq!(sarif["runs"][0]["tool"]["driver"]["name"], "flint");
+    assert_eq!(sarif["runs"][0]["results"], serde_json::json!([]));
+}
+
+#[test]
+fn checker_accepts_positional_repository_relative_paths() {
+    let repo = tempfile::tempdir().expect("temp repo");
+    std::fs::write(repo.path().join("renovate.json5"), "{}\n").unwrap();
+
+    let out = flint_with_env(&["checker", "renovate-deps", "README.md"], repo.path(), &[]);
+
+    assert!(out.status.success(), "{}", combined_output(&out));
+}


### PR DESCRIPTION
## Summary
Expose Flint-owned dependency and link checks to other runners without requiring Flint to select changed files or run the other linters:

```sh
printf '%s\n' mise.toml | flint checker renovate-deps --files-from -
flint checker renovate-deps --fix mise.toml
printf '%s\n' README.md | flint checker lychee --files-from -
```

- Accept positional repository-relative paths or a newline-delimited file list (`--files-from PATH`, including `-` for stdin). A final newline is optional.
- Emit SARIF on stdout for checker outcomes, with nonzero exit status on failure.
- Keep Renovate's relevance filtering, snapshot consistency and fix behavior inside Flint.
- Preserve lychee's repository-aware link policy, including the CI-wide local-link follow-up and required GitHub CI metadata. Caller selection does not bypass that policy.

The hk exploration in [docker-otel-lgtm#1796](https://github.com/grafana/docker-otel-lgtm/pull/1796) exercises both entry points with real selected file lists. This is a small interoperability API, not a commitment to retire Flint's runner or migrate every consumer.

## Validation
- `mise run lint:fix` and `mise run lint`
- `cargo test`
- Reproduced the hosted lychee test failure with inherited GitHub Actions environment variables; all three checker integration tests pass after sharing the existing isolated command builder with stdin-driven tests.
- The consumer PoC's full lint/CI runs have exercised the implementation at `137e9293`; the follow-up changes test isolation only.

Hosted Linux/macOS/Windows checks must pass before merge; local testing does not replace those platforms. After a release includes this API, the PoC can replace its immutable Git revision pin with a release pin.
